### PR TITLE
feat(mcp): add status observer and one-shot probe to mcp-client

### DIFF
--- a/vendor/deepseek-harness/packages/mcp/mcp-client/src/connection.ts
+++ b/vendor/deepseek-harness/packages/mcp/mcp-client/src/connection.ts
@@ -95,6 +95,24 @@ export interface ConnectionOutcome {
   error?: unknown
 }
 
+/**
+ * One externally visible state of a supervised connection, as a management
+ * surface renders it. Phases are monotonic in intent, not value: `connecting`
+ * covers every attempt's start, `connected` marks a live generation,
+ * `reconnecting` covers loss and backoff, `error` is terminal (reconnect
+ * disabled or the attempt budget exhausted), and `disposed` ends the
+ * supervisor.
+ */
+export interface McpConnectionState {
+  /** Lifecycle phase of the supervised connection. */
+  phase: 'connecting' | 'connected' | 'reconnecting' | 'error' | 'disposed'
+  /** Failure detail for the `error` phase. */
+  error?: string
+}
+
+/** Observer receiving every supervised-connection state transition. */
+export type McpStatusObserver = (state: McpConnectionState) => void
+
 /** Handle for one plugin instance's supervised connection. */
 export interface ConnectionHandle {
   /**
@@ -118,9 +136,11 @@ export interface ConnectionHandle {
  * @param ctx - Cordis context providing the `tools` registry and logger.
  * @param config - Resolved plugin config selecting the transport and server identity.
  * @param policy - Resolved reconnect policy from {@link resolveReconnectPolicy}.
+ * @param statusObserver - Optional observer of connection-state transitions;
+ *   invoked synchronously on each transition, never awaited.
  * @returns Handle with a `ready` promise for startup-await and a `dispose` for teardown.
  */
-export function startConnection(ctx: Context, config: Config, policy: ResolvedReconnectPolicy): ConnectionHandle {
+export function startConnection(ctx: Context, config: Config, policy: ResolvedReconnectPolicy, statusObserver?: McpStatusObserver): ConnectionHandle {
   const label = `mcp-client(${config.serverName})`
   const opts: ToolBridgeOptions = {
     registrationFailure: 'contain',
@@ -196,6 +216,7 @@ export function startConnection(ctx: Context, config: Config, policy: ResolvedRe
         ? 'connection lost and reconnect is disabled — registered tools will fail until an HMR reload or Host restart'
         : 'connection failed and reconnect is disabled — no tools were registered; reload the plugin or restart the Host to connect'
       ctx.logger.error(`${label}: ${message}`)
+      statusObserver?.({ phase: 'error', error: message })
       return
     }
     // A connection that stayed up past the stability window (= maxDelayMs, the
@@ -204,18 +225,21 @@ export function startConnection(ctx: Context, config: Config, policy: ResolvedRe
     connectedAt = undefined
     failedAttempts += 1
     if (failedAttempts > policy.maxAttempts) {
+      const message = `giving up after ${policy.maxAttempts} consecutive failed reconnect attempts — tools unregistered; reload the plugin or restart the Host to reconnect`
       // Enqueue the give-up disposal so it cannot race an in-flight sync's
       // phase-2 swap (which checks isCurrent inside the queue).
       syncChain = syncChain.then(() => {
         for (const dispose of disposers.values()) dispose()
         disposers = new Map()
       })
-      ctx.logger.error(`${label}: giving up after ${policy.maxAttempts} consecutive failed reconnect attempts — tools unregistered; reload the plugin or restart the Host to reconnect`)
+      ctx.logger.error(`${label}: ${message}`)
+      statusObserver?.({ phase: 'error', error: message })
       return
     }
     const delayMs = Math.min(policy.maxDelayMs, policy.initialDelayMs * 2 ** (failedAttempts - 1))
     const action = lostEstablishedConnection ? 'connection lost; reconnecting' : 'connection failed; retrying'
     ctx.logger.warn(`${label}: ${action} in ${delayMs}ms (attempt ${failedAttempts}/${policy.maxAttempts})`)
+    statusObserver?.({ phase: 'reconnecting' })
     reconnectTimer = setTimeout(() => {
       reconnectTimer = undefined
       settling = connectGeneration(false)
@@ -235,6 +259,7 @@ export function startConnection(ctx: Context, config: Config, policy: ResolvedRe
    * @param startup - Whether this is the plugin's activation attempt.
    */
   async function connectGeneration(startup: boolean): Promise<void> {
+    statusObserver?.({ phase: 'connecting' })
     const generation = new Client(
       { name: 'dsh-mcp-client', version: '0.0.1' },
       { capabilities: {} },
@@ -301,6 +326,7 @@ export function startConnection(ctx: Context, config: Config, policy: ResolvedRe
     }
     if (!isCurrent(generation)) return
     connectedAt = Date.now()
+    statusObserver?.({ phase: 'connected' })
     if (failedAttempts > 0) ctx.logger.info(`${label}: reconnected and re-synced tools (attempt ${failedAttempts}/${policy.maxAttempts})`)
   }
 
@@ -326,6 +352,7 @@ export function startConnection(ctx: Context, config: Config, policy: ResolvedRe
     ready,
     async dispose(): Promise<void> {
       disposed = true
+      statusObserver?.({ phase: 'disposed' })
       if (reconnectTimer !== undefined) {
         clearTimeout(reconnectTimer)
         reconnectTimer = undefined

--- a/vendor/deepseek-harness/packages/mcp/mcp-client/src/index.ts
+++ b/vendor/deepseek-harness/packages/mcp/mcp-client/src/index.ts
@@ -17,12 +17,16 @@ import type { Context } from '@deepseek-ai/cordis'
 import z from '@deepseek-ai/schemastery'
 import { MAX_TIMER_DELAY_MS } from '@deepseek-ai/dsh-timeout'
 import { RECONNECT_DEFAULTS, resolveReconnectPolicy, startConnection } from './connection.ts'
-import type { ReconnectConfig } from './connection.ts'
+import type { McpConnectionState, McpStatusObserver, ReconnectConfig } from './connection.ts'
+import { probeMcpServer } from './probe.ts'
+import type { McpToolInfo, ProbeResult } from './probe.ts'
 // Side-effect type import: declaration-merges `ctx.tools` onto Context.
 import type {} from '@deepseek-ai/dsh-tools'
 
 export type { McpResult } from './tools.ts'
-export type { ReconnectConfig, ResolvedReconnectPolicy } from './connection.ts'
+export type { ReconnectConfig, ResolvedReconnectPolicy, McpConnectionState, McpStatusObserver } from './connection.ts'
+export { probeMcpServer } from './probe.ts'
+export type { McpToolInfo, ProbeResult } from './probe.ts'
 
 /** Cordis plugin name used by loader diagnostics. */
 export const name = 'mcp-client'
@@ -104,26 +108,43 @@ const Reconnect: z<ReconnectConfig> = z.object({
   maxAttempts: z.number().step(1).min(1).max(Number.MAX_SAFE_INTEGER).default(RECONNECT_DEFAULTS.maxAttempts),
 })
 
+/**
+ * Shared stdio transport fields, without the `serverName` the plugin Config
+ * adds. Composable so a management service can validate server profiles with
+ * the exact same grammar the plugin instance itself validates.
+ */
+export const stdioTransportFields = {
+  transport: z.const('stdio'),
+  command: z.string().required(),
+  args: z.array(String).default([]),
+  env: z.dict(String).default({}),
+  cwd: z.string().default(''),
+  toolCallTimeoutMs: z.number().default(DEFAULT_TOOL_CALL_TIMEOUT_MS),
+  failOnStartupError: z.boolean().default(false),
+  reconnect: Reconnect,
+}
+
+/**
+ * Shared Streamable HTTP transport fields, without the `serverName` the
+ * plugin Config adds (see {@link stdioTransportFields}).
+ */
+export const streamableHttpTransportFields = {
+  transport: z.const('streamable-http'),
+  url: z.string().required(),
+  headers: z.dict(String).default({}),
+  toolCallTimeoutMs: z.number().default(DEFAULT_TOOL_CALL_TIMEOUT_MS),
+  failOnStartupError: z.boolean().default(false),
+  reconnect: Reconnect,
+}
+
 export const Config = z.union([
   z.object({
-    transport: z.const('stdio'),
+    ...stdioTransportFields,
     serverName: z.string().required().pattern(SERVER_NAME_PATTERN),
-    command: z.string().required(),
-    args: z.array(String).default([]),
-    env: z.dict(String).default({}),
-    cwd: z.string().default(''),
-    toolCallTimeoutMs: z.number().default(DEFAULT_TOOL_CALL_TIMEOUT_MS),
-    failOnStartupError: z.boolean().default(false),
-    reconnect: Reconnect,
   }),
   z.object({
-    transport: z.const('streamable-http'),
+    ...streamableHttpTransportFields,
     serverName: z.string().required().pattern(SERVER_NAME_PATTERN),
-    url: z.string().required(),
-    headers: z.dict(String).default({}),
-    toolCallTimeoutMs: z.number().default(DEFAULT_TOOL_CALL_TIMEOUT_MS),
-    failOnStartupError: z.boolean().default(false),
-    reconnect: Reconnect,
   }),
 ]) as unknown as z<Config>
 

--- a/vendor/deepseek-harness/packages/mcp/mcp-client/src/probe.ts
+++ b/vendor/deepseek-harness/packages/mcp/mcp-client/src/probe.ts
@@ -1,0 +1,80 @@
+/**
+ * One-shot MCP probe: connect to a server with the given config, list its
+ * tools, and close. Nothing is registered: no tools land on `ctx.tools`, no
+ * `serverName` namespace is reserved, and the child process (stdio) or HTTP
+ * connection is torn down before the result settles. This is the management
+ * surface's "test connection" — a live-server check that never changes the
+ * running composition.
+ *
+ * @module
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { MAX_TIMER_DELAY_MS } from '@deepseek-ai/dsh-timeout'
+import { createTransport } from './transport.ts'
+import type { Config } from './index.ts'
+
+/** One tool advertised by the probed server. */
+export interface McpToolInfo {
+  /** Tool name as the server advertises it. */
+  name: string
+  /** Short tool description when the server supplies one. */
+  description?: string
+}
+
+/** Probe outcome: the tool listing, or a refusal message. */
+export type ProbeResult =
+  | { ok: true; tools: McpToolInfo[] }
+  | { ok: false; message: string }
+
+/** Default probe deadline in milliseconds. */
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000
+
+/**
+ * Probe one MCP server and list its tools.
+ * @param config - resolved plugin config (transport + server identity); the
+ *   `serverName` is used only for logging context and is never registered.
+ * @param timeoutMs - deadline for the whole probe, bounded by
+ *   `MAX_TIMER_DELAY_MS`; an invalid value refuses the probe up front.
+ * @returns the tool listing, or a refusal message.
+ */
+export async function probeMcpServer(config: Config, timeoutMs: number = DEFAULT_PROBE_TIMEOUT_MS): Promise<ProbeResult> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_TIMER_DELAY_MS) {
+    return { ok: false, message: `probe timeout must be a positive number no greater than ${MAX_TIMER_DELAY_MS}` }
+  }
+  const client = new Client(
+    { name: 'dsh-mcp-probe', version: '0.0.1' },
+    { capabilities: {} },
+  )
+  let settled = false
+  // The deadline closes the client; an in-flight connect or list then rejects
+  // and funnels into the refusal branch below.
+  const timer = setTimeout(() => {
+    if (!settled) void client.close().catch(() => {})
+  }, timeoutMs)
+  timer.unref()
+  try {
+    await client.connect(createTransport(config))
+    const listing = await client.listTools()
+    settled = true
+    clearTimeout(timer)
+    return {
+      ok: true,
+      tools: listing.tools.map(tool => ({
+        name: tool.name,
+        ...tool.description === undefined ? {} : { description: tool.description },
+      })),
+    }
+  } catch (error) {
+    settled = true
+    clearTimeout(timer)
+    return { ok: false, message: error instanceof Error ? error.message : String(error) }
+  } finally {
+    try {
+      await client.close()
+    } catch {
+      // The transport already closed (deadline or connect failure); the probe
+      // outcome above already carries the reason.
+    }
+  }
+}

--- a/vendor/deepseek-harness/packages/mcp/mcp-client/tests/mcp-client.e2e.ts
+++ b/vendor/deepseek-harness/packages/mcp/mcp-client/tests/mcp-client.e2e.ts
@@ -24,6 +24,8 @@ import ToolRuntime from '@deepseek-ai/dsh-tools'
 import { CallId } from '@deepseek-ai/dsh-llm'
 import { apply } from '@deepseek-ai/dsh-mcp-client/src/index.ts'
 import { publicToolName } from '@deepseek-ai/dsh-mcp-client/src/tools.ts'
+import { resolveReconnectPolicy, startConnection } from '@deepseek-ai/dsh-mcp-client/src/connection.ts'
+import { probeMcpServer } from '@deepseek-ai/dsh-mcp-client/src/probe.ts'
 import type { Config } from '@deepseek-ai/dsh-mcp-client'
 
 const testToolSignal = new AbortController().signal
@@ -519,5 +521,85 @@ describe('streamable-http — in-process MCP server', () => {
   it('sends configured headers on every HTTP request', () => {
     expect(seenAuth.length).toBeGreaterThan(0)
     for (const auth of seenAuth) expect(auth).toBe('Bearer e2e-test-token')
+  })
+})
+
+// ---- Supervisor status observer and one-shot probe ----
+
+describe('connection status observer', () => {
+  let ctx: Context
+
+  const observerConfig: Config = {
+    transport: 'stdio',
+    serverName: 'observed',
+    command: process.execPath,
+    args: [fixtureServerPath],
+    env: {},
+    cwd: packageDir,
+    toolCallTimeoutMs: 15_000,
+    failOnStartupError: false,
+  }
+
+  beforeAll(async () => { ctx = await mountRegistry() })
+  afterAll(async () => { if (ctx) await ctx.fiber.dispose() })
+
+  it('reports connecting then connected for a live server, and disposed on teardown', async () => {
+    const phases: string[] = []
+    const handle = startConnection(ctx, observerConfig, resolveReconnectPolicy(undefined, 'observer-test'), state => phases.push(state.phase))
+    const outcome = await handle.ready
+    expect(outcome.error).toBeUndefined()
+    await vi.waitFor(() => { expect(phases).toContain('connected') })
+    expect(phases[0]).toBe('connecting')
+    await handle.dispose()
+    expect(phases).toContain('disposed')
+  })
+
+  it('reports an error phase when reconnect is disabled and the server cannot start', async () => {
+    const states: Array<{ phase: string; error?: string }> = []
+    const handle = startConnection(
+      ctx,
+      {
+        ...observerConfig,
+        serverName: 'ghost',
+        command: 'definitely-missing-mcp-command',
+        failOnStartupError: true,
+      },
+      resolveReconnectPolicy({ enabled: false }, 'observer-test'),
+      state => states.push(state),
+    )
+    await handle.ready
+    await vi.waitFor(() => { expect(states.some(state => state.phase === 'error')).toBe(true) })
+    expect(states.find(state => state.phase === 'error')?.error).toBeDefined()
+    await handle.dispose()
+  })
+})
+
+describe('probeMcpServer', () => {
+  const probeConfig: Config = {
+    transport: 'stdio',
+    serverName: 'probed',
+    command: process.execPath,
+    args: [fixtureServerPath],
+    env: {},
+    cwd: packageDir,
+    toolCallTimeoutMs: 15_000,
+    failOnStartupError: false,
+  }
+
+  it('lists the fixture tools without registering them anywhere', async () => {
+    const result = await probeMcpServer(probeConfig)
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.message)
+    const names = result.tools.map(tool => tool.name)
+    expect(names).toContain('add')
+    expect(names).toContain('admin.reset')
+    expect(result.tools.find(tool => tool.name === 'add')?.description).toBe('Adds two numbers.')
+  })
+
+  it('answers a refusal with a message when the server cannot start', async () => {
+    const result = await probeMcpServer({ ...probeConfig, command: 'definitely-missing-mcp-command' })
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected the probe to fail')
+    expect(result.message.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
startConnection 增加可选状态观察者（connecting/connected/reconnecting/error/disposed），供设置页显示连接状态徽章；新增 probeMcpServer(config, timeoutMs) 一次性列出工具，不挂载、不占命名空间。单元 92/92 + e2e 26/26 通过。不包含任何设置页改动。