### PR TITLE
feat(web): add input-type controls to pi-ai model rows and route default

### DIFF
--- a/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/ModelListEditor.tsx
+++ b/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/ModelListEditor.tsx
@@ -141,6 +141,31 @@ function effortsOf(model: ModelDraft): Record<string, string | null> {
 }
 
 /**
+ * Input types this form can declare, in the canonical pi-ai order (text
+ * first). The wire spelling is the same string (`text: text`); audio and
+ * other modalities wait for pi-ai upstream support.
+ */
+const INPUT_CHOICES = [
+  { id: 'text', key: 'inputText' },
+  { id: 'image', key: 'inputImage' },
+] as const satisfies readonly { id: string; key: keyof typeof en }[]
+
+type InputId = (typeof INPUT_CHOICES)[number]['id']
+
+/** One model's declared input types, or `undefined` when it declares none. */
+function inputOf(model: ModelDraft): readonly InputId[] | undefined {
+  const value = model['input']
+  if (!Array.isArray(value)) return undefined
+  const declared = value.filter((id): id is InputId => id === 'text' || id === 'image')
+  return declared.length === 0 ? undefined : declared
+}
+
+/** Reorder a declared set into the canonical choice order. */
+function orderedInput(selected: readonly InputId[]): InputId[] {
+  return INPUT_CHOICES.filter(choice => selected.includes(choice.id)).map(choice => choice.id)
+}
+
+/**
  * What an empty capacity field is worth, shown as its placeholder so a row left
  * blank does not read as a model with no capacity at all.
  *
@@ -257,6 +282,13 @@ export function ModelListEditor(props: ModelListEditorProps): ReactNode {
     else dict[id] = id
     const stillOffers = EFFORT_CHOICES.some(choice => Object.prototype.hasOwnProperty.call(dict, choice.id))
     patch(index, { reasoningEfforts: stillOffers ? dict : undefined })
+  }
+
+  /** Toggle one declared input type; an empty set removes the field (inherit). */
+  const toggleInput = (index: number, model: ModelDraft, id: InputId): void => {
+    const current = inputOf(model) ?? []
+    const next = current.includes(id) ? current.filter(existing => existing !== id) : [...current, id]
+    patch(index, { input: next.length === 0 ? undefined : orderedInput(next) })
   }
 
   const fetchModels = async (): Promise<void> => {
@@ -469,6 +501,29 @@ export function ModelListEditor(props: ModelListEditorProps): ReactNode {
                     onChange={(event) => { editCapacity(index, 'maxTokens', event.target.value) }}
                   />
                 </label>
+                <fieldset className={styles['effortGroup']}>
+                  <legend className={styles['modelFieldLabel']}>{t('inputTitle')}</legend>
+                  <div className={styles['effortOptions']}>
+                    {INPUT_CHOICES.map((choice) => {
+                      const checked = (inputOf(model) ?? []).includes(choice.id)
+                      return (
+                        <label className={styles['effortOption']} key={choice.id}>
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={disabled}
+                            aria-label={`${t(choice.key)} ${index + 1}`}
+                            onChange={() => { toggleInput(index, model, choice.id) }}
+                          />
+                          <span>{t(choice.key)}</span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                  {inputOf(model) === undefined
+                    ? <span className={styles['modelFieldLabel']}>{t('inputInherited')}</span>
+                    : null}
+                </fieldset>
               </div>
             )
             : null}

--- a/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/ProviderEditor.tsx
+++ b/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/ProviderEditor.tsx
@@ -42,6 +42,30 @@ type EditorLayout = 'deepseek' | 'pi-ai' | 'unknown'
 /** The public DeepSeek endpoint shown as the deepseek base-URL placeholder. */
 const DEEPSEEK_PUBLIC_BASE_URL = 'https://api.deepseek.com'
 
+/**
+ * Route-level default input types, in the canonical pi-ai order (text first).
+ * Applies to models on this route that declare none; audio and other
+ * modalities wait for pi-ai upstream support.
+ */
+const DEFAULT_INPUT_CHOICES = [
+  { id: 'text', key: 'inputText' },
+  { id: 'image', key: 'inputImage' },
+] as const satisfies readonly { id: string; key: keyof typeof en }[]
+
+type DefaultInputId = (typeof DEFAULT_INPUT_CHOICES)[number]['id']
+
+/** The route's drafted default input types, valid entries only. */
+function defaultInputOf(draft: Record<string, unknown>): readonly DefaultInputId[] {
+  const value = draft['defaultInput']
+  if (!Array.isArray(value)) return []
+  return value.filter((id): id is DefaultInputId => id === 'text' || id === 'image')
+}
+
+/** Reorder a declared set into the canonical choice order. */
+function orderedDefaultInput(selected: readonly DefaultInputId[]): DefaultInputId[] {
+  return DEFAULT_INPUT_CHOICES.filter(choice => selected.includes(choice.id)).map(choice => choice.id)
+}
+
 /** Props of {@link ProviderEditor}. */
 export interface ProviderEditorProps {
   /** Provider route id. */
@@ -205,6 +229,10 @@ export function ProviderEditor(props: ProviderEditorProps): ReactNode {
   // so a bad row is named by its position rather than by a blanket message.
   const modelFailure = validateDeepSeekModels(getPath(draft, ['models']))
   const keyFailure = apiKeyFailure(keyDraft)
+  // The route-level default input types: only an explicitly drafted empty set
+  // blocks the write (an absent field inherits the adapter's `['text']`).
+  const defaultInput = defaultInputOf(draft)
+  const defaultInputEmpty = hasPath(draft, ['defaultInput']) && defaultInput.length === 0
   // What a probe or a write must carry: the typed key with paste whitespace
   // removed. A blank field yields an empty string, which both call sites read
   // as "no key supplied" rather than as a key — that is how a card whose
@@ -452,6 +480,41 @@ export function ProviderEditor(props: ProviderEditorProps): ReactNode {
                 </div>
               )
               : null}
+            {/* The route-level default input types: the fallback a model with
+                no declaration of its own inherits. Empty is refused — nothing
+                sits below it to answer instead. */}
+            {family === 'pi-ai'
+              ? (
+                <fieldset className={styles['effortGroup']}>
+                  <legend className={styles['modelFieldLabel']}>{t('defaultInputTitle')}</legend>
+                  <div className={styles['effortOptions']}>
+                    {DEFAULT_INPUT_CHOICES.map((choice) => {
+                      const checked = defaultInput.includes(choice.id)
+                      return (
+                        <label className={styles['effortOption']} key={choice.id}>
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            disabled={disabled}
+                            aria-label={t(choice.key)}
+                            onChange={() => {
+                              const next = checked
+                                ? defaultInput.filter(existing => existing !== choice.id)
+                                : orderedDefaultInput([...defaultInput, choice.id])
+                              setDraft(current => setPath(current, ['defaultInput'], next))
+                            }}
+                          />
+                          <span>{t(choice.key)}</span>
+                        </label>
+                      )
+                    })}
+                  </div>
+                  {defaultInputEmpty
+                    ? <p className={styles['error']}>{t('defaultInputEmpty')}</p>
+                    : <span className={styles['modelFieldLabel']}>{t('defaultInputHint')}</span>}
+                </fieldset>
+              )
+              : null}
             {/* Both families edit the same rows through the same contract; only
                 the extras differ — DeepSeek's inherited capacities, pi-ai's
                 endpoint interrogation. */}
@@ -500,6 +563,7 @@ export function ProviderEditor(props: ProviderEditorProps): ReactNode {
         t={t}
         busy={busy}
         submitDisabled={disabled || layout === 'unknown'
+          || (layout === 'pi-ai' && defaultInputEmpty)
           || (props.credentialOnly !== true && modelFailure !== undefined)
           || shownKeyFailure !== undefined
           || (props.credentialRequired === true && keyValue.length === 0)}

--- a/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/locales.ts
+++ b/vendor/deepseek-harness/packages/client/ui-settings-models/src/client/locales.ts
@@ -108,6 +108,13 @@ export const en = {
   visionModelOff: 'Off',
   visionModelSaveFailed: 'Saving the vision model failed',
   visionModelLoadFailed: 'Loading the model list failed',
+  inputTitle: 'Input types',
+  inputText: 'Text',
+  inputImage: 'Image',
+  inputInherited: 'Not set — inherits the provider defaults.',
+  defaultInputTitle: 'Default input types',
+  defaultInputHint: 'Applies to models on this route that declare none. Text is always accepted by any supported protocol.',
+  defaultInputEmpty: 'Pick at least one input type.',
 }
 
 /** The settings.models namespace key union. */
@@ -219,4 +226,11 @@ export const zh: { [Key in keyof typeof en]: string } = {
   visionModelOff: '不启用',
   visionModelSaveFailed: '保存识图模型失败',
   visionModelLoadFailed: '加载模型列表失败',
+  inputTitle: '输入类型',
+  inputText: '文本',
+  inputImage: '图像',
+  inputInherited: '未设置——继承提供方默认值。',
+  defaultInputTitle: '默认输入类型',
+  defaultInputHint: '应用于本路由下未声明的模型。任何受支持协议都必然接受文本。',
+  defaultInputEmpty: '请至少选择一种输入类型。',
 }

--- a/vendor/deepseek-harness/packages/client/ui-settings-models/tests/components.client.spec.tsx
+++ b/vendor/deepseek-harness/packages/client/ui-settings-models/tests/components.client.spec.tsx
@@ -2,6 +2,8 @@
 /** Section, setup-card, and hand-written editor behavior over a scripted wire face. */
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useState } from 'react'
+import type { ReactNode } from 'react'
 import Schema from '@deepseek-ai/schemastery'
 import { bindSnapshotSelector } from '@deepseek-ai/dsh-client-web-react'
 import type { RpcResponse, SettingsNamespaceView } from '@deepseek-ai/dsh-api-remotes/client'
@@ -13,6 +15,8 @@ import { pathOps } from '../src/client/ProviderEditor.tsx'
 import {
   DeepSeekModelsEditor, formatCapacity, modelDrafts, parseCapacity, validateDeepSeekModels,
 } from '../src/client/DeepSeekModelsEditor.tsx'
+import { ModelListEditor } from '../src/client/ModelListEditor.tsx'
+import type { ModelDraft, ProbeTarget } from '../src/client/ModelListEditor.tsx'
 import { apiKeyFailure } from '../src/client/apiKey.ts'
 import { deriveKeyRef, ModelsSettingsStore } from '../src/client/store.ts'
 import type { ProviderRow } from '../src/client/store.ts'
@@ -1330,6 +1334,88 @@ describe('ModelsSection', () => {
       { settingsNs: 'llm-pi-ai', settingsPath: ['providers', 'openai'] },
     )
     expect(failure).toBe('connection lost')
+  })
+})
+
+describe('input types', () => {
+  it('declares input types per model row and writes the canonical order', async () => {
+    const { mutate } = await mountSection()
+    fireEvent.click(screen.getByRole('button', { name: openaiCopy(en.editProvider) }))
+    await screen.findByLabelText(en.keyInput)
+    fireEvent.click(screen.getByText(en.customized))
+    fireEvent.click(screen.getByText(en.addModel))
+    const ids = screen.getAllByLabelText(new RegExp(en.modelId))
+    fireEvent.change(ids[0] as HTMLInputElement, { target: { value: 'vision-model' } })
+    expandRow(1)
+    // No declaration yet: the inheritance hint shows, and nothing is stored.
+    expect(screen.getByText(en.inputInherited)).toBeTruthy()
+    fireEvent.click(screen.getByLabelText(`${en.inputImage} 1`))
+    fireEvent.click(screen.getByText(en.apply))
+    await waitFor(() => { expect(mutate).toHaveBeenCalledTimes(1) })
+    expect(mutate.mock.calls[0]?.[0]).toEqual({
+      ns: 'llm-pi-ai',
+      ops: [{
+        op: 'set',
+        path: ['providers', 'openai', 'models'],
+        value: [{ id: 'vision-model', input: ['image'] }],
+      }],
+      expectedRevision: 0,
+    })
+  })
+
+  it('declares and clears input types on a directly rendered row', () => {
+    const onChange = vi.fn()
+    const probe: ProbeTarget = { settingsNs: 'llm-pi-ai' }
+    function StatefulListEditor(): ReactNode {
+      const [models, setModels] = useState<ModelDraft[]>([{ id: 'm', input: ['text', 'image'] }])
+      return (
+        <ModelListEditor
+          models={models}
+          overridden={false}
+          probe={probe}
+          api={{ llm: { discoverModels: vi.fn() } } as never}
+          t={t}
+          disabled={false}
+          onChange={(next) => { onChange(next); setModels(next) }}
+        />
+      )
+    }
+    render(<StatefulListEditor />)
+    expandRow(1)
+    const image = screen.getByLabelText(`${en.inputImage} 1`) as HTMLInputElement
+    expect(image.checked).toBe(true)
+    fireEvent.click(image)
+    expect(onChange).toHaveBeenNthCalledWith(1, [{ id: 'm', input: ['text'] }])
+    fireEvent.click(screen.getByLabelText(`${en.inputText} 1`))
+    // Clearing the last declared type removes the field: inherit.
+    expect(onChange).toHaveBeenNthCalledWith(2, [{ id: 'm' }])
+    expect(screen.getByText(en.inputInherited)).toBeTruthy()
+  })
+
+  it('requires a non-empty route-level default input for pi-ai', async () => {
+    const { mutate } = await mountSection()
+    fireEvent.click(screen.getByRole('button', { name: openaiCopy(en.editProvider) }))
+    await screen.findByLabelText(en.keyInput)
+    fireEvent.click(screen.getByText(en.customized))
+    const text = screen.getByLabelText(en.inputText) as HTMLInputElement
+    // The fixture stores no defaultInput: the field is absent, so nothing
+    // blocks the write and the hint explains inheritance.
+    expect(text.checked).toBe(false)
+    expect(screen.getByText(en.defaultInputHint)).toBeTruthy()
+    expect((screen.getByText(en.apply) as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(text)
+    fireEvent.click(screen.getByLabelText(en.inputText))
+    // An explicitly emptied set is refused, like the host grammar refuses it.
+    expect(await screen.findByText(en.defaultInputEmpty)).toBeTruthy()
+    expect((screen.getByText(en.apply) as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(screen.getByLabelText(en.inputImage))
+    fireEvent.click(screen.getByText(en.apply))
+    await waitFor(() => { expect(mutate).toHaveBeenCalledTimes(1) })
+    expect(mutate.mock.calls[0]?.[0]).toEqual({
+      ns: 'llm-pi-ai',
+      ops: [{ op: 'set', path: ['providers', 'openai', 'defaultInput'], value: ['image'] }],
+      expectedRevision: 0,
+    })
   })
 })
 

--- a/vendor/deepseek-harness/packages/client/ui-settings-models/tests/provider-form.client.spec.tsx
+++ b/vendor/deepseek-harness/packages/client/ui-settings-models/tests/provider-form.client.spec.tsx
@@ -632,7 +632,10 @@ describe('endpoint interrogation', () => {
 
     fireEvent.click(screen.getByText(en.fetchModels))
     await screen.findByText(en.fetchTitle)
-    const boxes = [...document.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')]
+    // The picker dialog's own checkboxes, scoped to the dialog: the editor
+    // behind it now owns checkboxes of its own (input types).
+    const dialog = screen.getByRole('dialog', { name: en.fetchTitle })
+    const boxes = [...dialog.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')]
     const first = boxes[0] as HTMLInputElement
     fireEvent.click(first)
     fireEvent.click(first)
@@ -763,11 +766,12 @@ describe('hand-declared providers', () => {
     cleanup()
 
     // A shipped route's models each carry their own protocol, so its editor
-    // offers no route-level protocol to override them with.
+    // offers no route-level protocol to override them with; the route-level
+    // default input types are its own fallback control.
     await mountSection({ providers: { openai: { apiKeyEnv: 'OPENAI_API_KEY' } } })
     openEditor('openai')
     fireEvent.click(screen.getByText(en.customized))
-    expect(fields()).toEqual([en.keyInput, en.baseUrl])
+    expect(fields()).toEqual([en.keyInput, en.baseUrl, en.inputText, en.inputImage])
     cleanup()
 
     // A hand-declared route named its own protocol at creation, so editing it
@@ -777,7 +781,9 @@ describe('hand-declared providers', () => {
       declaredRoutes: ['acme-gateway'],
     })
     openEditor('acme-gateway')
-    expect(fields()).toEqual([en.keyInput, en.customDisplayName, en.baseUrl, en.customApi])
+    expect(fields()).toEqual([
+      en.keyInput, en.customDisplayName, en.baseUrl, en.customApi, en.inputText, en.inputImage,
+    ])
   })
 
   it('renames a declared route and falls back to its id when the name is cleared', async () => {


### PR DESCRIPTION
pi-ai 自定义供应商的模型行高级区新增「输入类型」复选框（文本/图像），空 = 删除字段 = 继承；路由编辑器新增「默认输入类型」写入 defaultInput，显式清空会以内联错误阻止提交，与主机端拒绝一致。DeepSeek 官方模型不动。