### PR TITLE
fix(pack): keep shipped agent-preset SKILL.md in the runtime tar

### DIFF
--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -129,6 +129,15 @@ function realOf(target) {
   }
 }
 
+/** Runtime skill files under shipped agent presets are Markdown (`SKILL.md`). */
+function isShippedPresetMarkdown(src, root, base) {
+  if (!/\.md$/i.test(base)) {
+    return false;
+  }
+  const rel = path.relative(path.resolve(root), path.resolve(src)).split(path.sep);
+  return rel.includes('agent-presets');
+}
+
 /**
  * 收集需要复制的文件：
  * - 递归 + 回溯维护祖先链（防符号链接环），复用同一个 Set，避免 O(n²) 内存
@@ -195,7 +204,7 @@ function collectFiles(root, destRoot, expandNested = false, flat = false) {
 
     if (lstat.isFile()) {
       const base = path.basename(src);
-      if (/\.(map|tsbuildinfo|md|d\.ts)$/i.test(base)) {
+      if (/\.(map|tsbuildinfo|md|d\.ts)$/i.test(base) && !isShippedPresetMarkdown(src, root, base)) {
         return;
       }
       if (/^(license|licence|changelog|changes|authors|contributing)(\.|$)/i.test(base)) {

--- a/src/main/after-pack.test.js
+++ b/src/main/after-pack.test.js
@@ -61,6 +61,83 @@ test('collectFiles deduplicates a linked package flattened to the same destinati
   );
 });
 
+test('collectFiles keeps shipped preset SKILL.md while stripping other markdown', (t) => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'after-pack-skills-'));
+  t.after(() => fs.rmSync(workspace, { recursive: true, force: true }));
+  const source = path.join(workspace, 'source');
+  const destination = path.join(workspace, 'destination');
+  const skill = path.join(
+    source,
+    'apps',
+    'cli',
+    'config',
+    'agent-presets',
+    'cordis',
+    'skills',
+    'editing-cordis-compositions',
+    'SKILL.md',
+  );
+  const readme = path.join(source, 'apps', 'cli', 'README.md');
+  const preset = path.join(source, 'apps', 'cli', 'config', 'agent-presets', 'cordis', 'preset.yml');
+  fs.mkdirSync(path.dirname(skill), { recursive: true });
+  fs.mkdirSync(path.dirname(readme), { recursive: true });
+  fs.writeFileSync(skill, '# editing cordis compositions\n');
+  fs.writeFileSync(readme, '# cli docs\n');
+  fs.writeFileSync(preset, 'id: cordis\n');
+
+  const files = collectFiles(source, destination, false, true);
+  const destinations = files.map(({ dest }) => path.relative(destination, dest)).sort();
+
+  assert.deepEqual(
+    destinations,
+    [
+      path.join('apps', 'cli', 'config', 'agent-presets', 'cordis', 'preset.yml'),
+      path.join(
+        'apps',
+        'cli',
+        'config',
+        'agent-presets',
+        'cordis',
+        'skills',
+        'editing-cordis-compositions',
+        'SKILL.md',
+      ),
+    ],
+  );
+});
+
+test('collectFiles keeps preset SKILL.md when rooted at the deploy config directory', (t) => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'after-pack-deploy-skills-'));
+  t.after(() => fs.rmSync(workspace, { recursive: true, force: true }));
+  const source = path.join(workspace, 'config');
+  const destination = path.join(workspace, 'destination');
+  const skill = path.join(
+    source,
+    'agent-presets',
+    'cordis',
+    'skills',
+    'cordis-plugin-development',
+    'SKILL.md',
+  );
+  const readme = path.join(source, 'README.md');
+  const preset = path.join(source, 'agent-presets', 'cordis', 'preset.yml');
+  fs.mkdirSync(path.dirname(skill), { recursive: true });
+  fs.writeFileSync(skill, '# cordis plugin development\n');
+  fs.writeFileSync(readme, '# config docs\n');
+  fs.writeFileSync(preset, 'id: cordis\n');
+
+  const files = collectFiles(source, destination, true, false);
+  const destinations = files.map(({ dest }) => path.relative(destination, dest)).sort();
+
+  assert.deepEqual(
+    destinations,
+    [
+      path.join('agent-presets', 'cordis', 'preset.yml'),
+      path.join('agent-presets', 'cordis', 'skills', 'cordis-plugin-development', 'SKILL.md'),
+    ],
+  );
+});
+
 test('collectFiles preserves a linked package copied to distinct destinations', (t) => {
   const fixture = makeFixture(t);
   linkPackage(fixture.source, fixture.shared, 'a');


### PR DESCRIPTION
## Summary
- After-pack `collectFiles()` kept stripping all Markdown, so the cordis preset `skills/` directories never reached installed builds (only `SKILL.md` lives there).
- Keep Markdown under `agent-presets` on both the full-vendor pack path and the `DSH_DEPLOY_DIR` config root; other docs still drop.
- Regression tests cover both collection roots.

Fixes #8

## Test plan
- [x] `node --test src/main/after-pack.test.js` (12/12)
- [x] Watched the new tests fail before the filter change, then pass
