### PR TITLE
审查修复：data-import / harness-extract / 冷启动超时 / 发布门禁等加固

### DIFF
--- a/.cursor/rules/data-import-product.mdc
+++ b/.cursor/rules/data-import-product.mdc
@@ -7,6 +7,6 @@ alwaysApply: true
 
 Dest is always desktop `userData/dsh-home`. Auto-scan (read-only): `~/.dsh` (sessions, attachments, plugin list, `skills/`, `mcp-servers.yaml`) plus `~/.agents/skills`. Extra source dirs are additional roots, not a dest picker.
 
-`runImport` requires checkboxes. Empty selection writes nothing. Plugins reinstall by spec (`dsh plugin add`); never copy `node_modules`. MCP merges by id into dest YAML (tokens on disk, never in UI/logs). Official `~/.dsh` and `~/.agents` stay read-only.
+`runImport` requires checkboxes. Empty selection writes nothing. Plugins reinstall by spec (`dsh plugin add`) through two controlled channels only: `github:owner/repo[#ref]` and registry `name@<semver>`; anything else is pre-marked `unsupported` in the scan (greyed row). Never copy `node_modules`. MCP merges by id into dest YAML (tokens on disk, never in UI/logs). Official `~/.dsh` and `~/.agents` stay read-only. A `phase:'copying'` journal is consumed at cold start: clean `.import-tmp`, hold on import tab, re-run is idempotent (conflict skip).
 
 Full card: [docs/features/data-import.md](../../docs/features/data-import.md)

--- a/.cursor/rules/dsh-home-product.mdc
+++ b/.cursor/rules/dsh-home-product.mdc
@@ -5,9 +5,9 @@ alwaysApply: true
 
 # Desktop Harness home
 
-Desktop `$DSH_HOME` is `userData/dsh-home` only (`DSHD_HOME` for debug). Harness/PTY/`process.env.DSH_HOME` must not read, write, or clean official `~/.dsh`. The shell launcher may read `~/.dsh` and `~/.agents/skills` only for an explicit user-confirmed checkbox import.
+Desktop `$DSH_HOME` is `userData/dsh-home` only (`DSHD_HOME` for debug; packaged builds drop an inherited `DSHD_HOME` unless `DSHD_ALLOW_ENV_HOME=1`). Harness/PTY/`process.env.DSH_HOME` must not read, write, or clean official `~/.dsh`. The shell launcher may read `~/.dsh` and `~/.agents/skills` only for an explicit user-confirmed checkbox import.
 
-Marketplace / `dsh plugin` installs into `dsh-home/profiles/web`. Do not set Electron `process.env.DSH_HOME`; PTY must not inject it. `dsh web` and `dsh plugin` children overwrite `DSH_HOME` to the desktop home. Child `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` only when shell `baseUrl` is empty or `api.deepseek.com`.
+Marketplace / `dsh plugin` installs into `dsh-home/profiles/web`. Do not set Electron `process.env.DSH_HOME`; PTY must not inject it. `dsh web` and `dsh plugin` children overwrite `DSH_HOME` to the desktop home. Child `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` only when shell `baseUrl` is empty or `https://api.deepseek.com` (https only).
 
 Ignore inherited `DSH_HOME`. Profile name stays `web`. Skip-user-plugins FSM unchanged.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,10 +80,14 @@ jobs:
 
   release:
     needs: [windows, macos]
+    # Publishing policy: the Windows installer gates the release; macOS is
+    # best-effort. When the macos job fails, the release still ships but
+    # simply carries no .dmg asset (nullglob below drops the empty pattern).
     if: ${{ always() && startsWith(github.ref, 'refs/tags/') && needs.windows.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,6 +99,23 @@ jobs:
 
       - name: Verify tag matches package version
         run: node scripts/check-release-version.mjs "$GITHUB_REF_NAME"
+
+      # Quality gate: the release job intentionally does not re-run the test
+      # suites (see ci-isolation.test.js); instead it requires that the
+      # "Desktop tests" workflow already passed for this exact commit.
+      - name: Require green Desktop tests for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          count=$(gh api \
+            "repos/$GITHUB_REPOSITORY/actions/workflows/test.yml/runs?head_sha=$GITHUB_SHA&status=success&per_page=1" \
+            --jq '.total_count')
+          if [ "${count:-0}" -lt 1 ]; then
+            echo "No green Desktop tests run found for $GITHUB_SHA." >&2
+            echo "让同一提交先在 CI（test.yml）变绿，再打 tag 发版。" >&2
+            exit 1
+          fi
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,21 @@ jobs:
           path: dist-out
           merge-multiple: true
 
+      # SHA512SUMS.txt lets the desktop updater (src/main/update.js) verify
+      # the downloaded Setup asset; releases without it install unverified.
+      - name: Write SHA512SUMS.txt
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          cd dist-out
+          files=(Deepseek-Harness-Desktop-Setup-*.exe Deepseek-Harness-Desktop-Setup-*.exe.blockmap Deepseek-Harness-Desktop-*.dmg)
+          if (( ${#files[@]} == 0 )); then
+            echo "No release artifacts to checksum." >&2
+            exit 1
+          fi
+          sha512sum "${files[@]}" > SHA512SUMS.txt
+          cat SHA512SUMS.txt
+
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -134,7 +149,7 @@ jobs:
             echo "Windows release artifacts are missing." >&2
             exit 1
           fi
-          assets=("${windows[@]}" "${macos[@]}")
+          assets=("${windows[@]}" "${macos[@]}" dist-out/SHA512SUMS.txt)
           gh release create "$GITHUB_REF_NAME" "${assets[@]}" \
             --repo "$GITHUB_REPOSITORY" \
             --title "Deepseek-Harness-Desktop $GITHUB_REF_NAME" \

--- a/docs/features/data-import.md
+++ b/docs/features/data-import.md
@@ -4,16 +4,16 @@
 | --- | --- |
 | **id** | `data-import` |
 | **status** | `active` |
-| **last verified** | 2026-08-24 — 启动器导入改为分类页签 + 底栏主按钮；会话按目录分组；IPC 勾选契约未改 |
+| **last verified** | 2026-08-24 — 插件重装新增受控 registry `name@semver` 通道并预标 unsupported；journal `copying` 由启动器消费（清 `.import-tmp` + 提示重跑） |
 
 ## User paths
 
 1. 启动器「导入」自动只读扫描官方 `~/.dsh`（会话、附件、`profiles/web/package.json` 插件名单、`skills/`、`mcp-servers.yaml`）以及 `~/.agents/skills`。
 2. 「选择目录」另加一个按 home 布局扫描的来源；「添加技能目录」把含 `SKILL.md` 的根并入技能列表。不扫项目仓库，除非用户主动选中该文件夹。
 3. 导入页用分类页签勾选会话 / 技能 / 插件 / MCP，默认可导入项全勾。空选点导入 = 不写盘。落点固定桌面 `userData/dsh-home`。
-4. 插件只按名单 `dsh plugin add` 重装，不拷 `node_modules` / `desktop-plugins`。本地 `file:` / `link:` / `workspace:`、模板包、已下架包为禁用行。
+4. 插件只按名单 `dsh plugin add` 重装，不拷 `node_modules` / `desktop-plugins`。支持两条受控通道：`github:owner/repo[#ref]` 与官方 registry semver（重装为 `name@<semver>`，含 `^`/`~`）。本地 `file:` / `link:` / `workspace:`、模板包、已下架包、其余规格（tarball URL、dist-tag、npm alias 等）在扫描时预标禁用行（`unsupported`），UI 灰置并给理由，勾不了也不会送进 `pnpm add`。
 5. MCP 按 id merge 进桌面 `mcp-servers.yaml`（含 header/token）；UI 与日志不展示密钥。附件整树拷 `attachments/`。
-6. 导入时若桌面端在跑：先停内核。崩溃后续跑 journal。
+6. 导入时若桌面端在跑：先停内核。导入本身幂等（conflict 默认 skip）。崩溃续跑：冷启动闸门消费 `phase:'copying'` 的 journal——清理桌面 home 下残留 `.import-tmp` staging 目录、journal 改写为 `recovered`、启动器停在导入页并提示可安全重跑。
 
 ## Invariants
 
@@ -22,7 +22,8 @@
 - 不拷工作区工程树、项目 `.dsh/skills`（除非用户把该目录选进来源）、`profiles/`、凭据、`settings.yaml`、旧 SQLite 会话库。
 - 不改会话文件夹名、不改写 jsonl。旧 rc `.db` 标不兼容并跳过。
 - `runImport` 必收勾选；省略选择 = 零写入。路径穿越与源根外技能路径拒绝落盘。
-- journal 在 `userData/import-journal.json`，不在 `dsh-home/sessions` 里。
+- 插件重装规格只允许 `github:owner/repo[#ref]` 或 `name@<semver>`（`installImportPlugin` 受控通道，仅主进程 LAUNCHER IPC 使用）；渲染进程 / 工具的 `installPlugin` 通道保持 github-only。
+- journal 在 `userData/import-journal.json`，不在 `dsh-home/sessions` 里。`recoverInterruptedImport` 只清 journal 自己的 destHome 且必须等于当前桌面 home；官方来源仍只读。
 
 ## Allowed touch
 

--- a/docs/features/data-import.md
+++ b/docs/features/data-import.md
@@ -24,6 +24,7 @@
 - `runImport` 必收勾选；省略选择 = 零写入。路径穿越与源根外技能路径拒绝落盘。
 - 插件重装规格只允许 `github:owner/repo[#ref]` 或 `name@<semver>`（`installImportPlugin` 受控通道，仅主进程 LAUNCHER IPC 使用）；渲染进程 / 工具的 `installPlugin` 通道保持 github-only。
 - journal 在 `userData/import-journal.json`，不在 `dsh-home/sessions` 里。`recoverInterruptedImport` 只清 journal 自己的 destHome 且必须等于当前桌面 home；官方来源仍只读。
+- 已知权衡（MCP 凭据）：MCP merge 原样拷贝 header/token 进桌面 `mcp-servers.yaml`（明文，与官方 CLI 相同的落盘形态）；OAuth 类服务器的会话态/刷新令牌不迁移，导入后可能需在桌面端重新授权。桌面不回写官方文件。
 
 ## Allowed touch
 

--- a/docs/features/desktop-launcher.md
+++ b/docs/features/desktop-launcher.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `desktop-launcher` |
 | **status** | `active` |
-| **last verified** | 2026-08-24 — 导入页改为分类页签 + 底栏主按钮；官方浅色/深色表不变 |
+| **last verified** | 2026-08-24 — 更新检查/下载加超时；Release 带 SHA512SUMS.txt 时下载后强制校验 |
 
 ## User paths
 
@@ -21,6 +21,8 @@
 - 市场 / 壁纸图库仍禁止另开产品窗。
 - `/releases/latest` 忽略 draft；草稿 0.2.7 不得当成现网更新源。
 - 换版本只下载该 tag 的 Setup 并拉起安装器，不单独切 `vendor/dsh` pin。
+- 更新检查请求 10s 超时、单次下载整体 15 分钟超时；失败不阻塞手动「启动桌面端」。
+- Release 若带 `SHA512SUMS.txt`，下载后强制 sha512 校验（失败即删除并报错）；老版本 Release 无清单则跳过校验（已知限制，见 build-release handbook）。
 - 关启动器：桌面主窗还在则只关启动器；主窗不在则退出应用。
 
 ## Allowed touch

--- a/docs/features/dsh-home.md
+++ b/docs/features/dsh-home.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `dsh-home` |
 | **status** | `active` |
-| **last verified** | 2026-08-23 — 打开运行目录；applyDesktopDshHome case-fold + spawn env；TC-INST-011b |
+| **last verified** | 2026-08-24 — packaged 下 `DSHD_HOME` 需 `DSHD_ALLOW_ENV_HOME=1`；`isOfficialDeepSeekBaseUrl` 仅 https |
 
 ## User paths
 
@@ -16,11 +16,11 @@
 
 ## Invariants
 
-- 桌面 `$DSH_HOME` 仅为 `userData/dsh-home`（测试/调试可用 `DSHD_HOME`）。忽略环境 `DSH_HOME`，永不回落 `~/.dsh`。
+- 桌面 `$DSH_HOME` 仅为 `userData/dsh-home`（测试/调试可用 `DSHD_HOME`；packaged 构建忽略继承的 `DSHD_HOME`，除非显式 `DSHD_ALLOW_ENV_HOME=1`）。忽略环境 `DSH_HOME`，永不回落 `~/.dsh`。
 - 桌面 **Harness / PTY / `process.env.DSH_HOME`** 不读、不写、不清理 `~/.dsh`。壳层启动器可**只读**官方 home、`~/.agents/skills` 与用户另选的技能根，以及官方 `mcp-servers.yaml`，做用户确认后的勾选导入（见 [data-import](data-import.md)）；禁止静默自动迁、禁止写回或删除官方文件。
 - 不把桌面 home 写进 Electron `process.env.DSH_HOME`；PTY 不注入该值。
 - `dsh web` 与 `dsh plugin` 子进程的 `DSH_HOME` 覆盖为桌面 home。
-- 子进程 `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` 仅在壳层 `baseUrl` 为空或主机为 `api.deepseek.com` 时写入；第三方网关只留给自定义提供方。
+- 子进程 `DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` 仅在壳层 `baseUrl` 为空或为 `https://api.deepseek.com`（仅 https，不接受明文 http）时写入；第三方网关只留给自定义提供方。
 - 渲染进程不得把路径交给打开接口；主进程只打开已绑定的桌面 home。
 - `--skip-user-plugins` 恢复状态机不变。
 

--- a/docs/features/git-titlebar.md
+++ b/docs/features/git-titlebar.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `git-titlebar` |
 | **status** | `active` |
-| **last verified** | 2026-08-23 — 验收合同改为 CI 安装包全表；`qa:packaged` 仅 rehearsal |
+| **last verified** | 2026-08-24 — 登记信任根新增高危祖先过滤（用户主目录 / APPDATA / userData / dsh-home）；兄弟项目场景不变 |
 
 ## User paths
 
@@ -17,6 +17,7 @@
 - 会话 cwd 只要是桌面 `dsh-home` 已登记的工作区目录（或启动工作区及其子目录），Git IPC 就对该路径生效。
 - 登记路径可以是启动工作区的**兄弟目录**（例如 `Documents\Deepseek-Harness-Desktop` 启动、`C:\Ai\ChisaTerminal` 为当前项目）。
 - `workspace.json` 里的盘符根（`C:\`、`/`）不得进入 Git/FS/PTY 白名单。
+- 高危祖先也不得成为登记信任根：用户主目录、`%APPDATA%` / `Application Support` / `~/.config` / `~/.ssh`、desktop `userData` 与 `dsh-home` 根（等于这些目录、或包含它们的目录一律拒绝）。普通项目目录（含 Documents 下兄弟仓）不受影响。
 - 非仓库降级（初始化 Git），不把授权失败画成「没有匹配的分支」。
 - 官方 `dsh web` 标题栏 Git 视觉；不另做皮肤。
 

--- a/docs/features/git-titlebar.md
+++ b/docs/features/git-titlebar.md
@@ -19,6 +19,7 @@
 - `workspace.json` 里的盘符根（`C:\`、`/`）不得进入 Git/FS/PTY 白名单。
 - 高危祖先也不得成为登记信任根：用户主目录、`%APPDATA%` / `Application Support` / `~/.config` / `~/.ssh`、desktop `userData` 与 `dsh-home` 根（等于这些目录、或包含它们的目录一律拒绝）。普通项目目录（含 Documents 下兄弟仓）不受影响。
 - 非仓库降级（初始化 Git），不把授权失败画成「没有匹配的分支」。
+- 已知权衡（信任粒度）：通过过滤的登记根对 Git/FS/PTY 全量生效，不做逐操作确认；边界是「登记只来自用户主动打开的工作区」加上盘符根与高危祖先过滤。
 - 官方 `dsh web` 标题栏 Git 视觉；不另做皮肤。
 
 ## Allowed touch

--- a/docs/features/wallpaper-gallery.md
+++ b/docs/features/wallpaper-gallery.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `wallpaper-gallery` |
 | **status** | `active` |
-| **last verified** | 2026-08-23 — catalog `fetch failed` / 超时解包为「网络失败」「超时」 |
+| **last verified** | 2026-08-24 — SSRF 加固：封 CGNAT/benchmark 网段并在 DNS 解析后复检 IP |
 
 ## User paths
 
@@ -19,7 +19,7 @@
 - Appearance 壁纸行**只**做：挑选、浏览、裁剪、frost、pixelate。无源列表、无 JSON URL、无 Bing 开关堆在 Appearance。
 - 浏览打开**同一产品窗**（非独立 Electron 市场窗）：分类 + 搜索在上，网格在下。
 - 全部图源 CRUD 只在图库窗内；禁止把配置倾倒到 Appearance。
-- 用户源为具名 HTTPS JSON 目录。主进程拒绝 loopback / RFC1918 / link-local 目录与下载（`DSHD_WALLPAPER_ALLOW_HTTP=1` 仅测试机）。
+- 用户源为具名 HTTPS JSON 目录。主进程拒绝 loopback / RFC1918 / link-local / CGNAT（100.64.0.0/10）/ benchmark（198.18.0.0/15）目录与下载，且主机名在 DNS 解析后复检 IP（`DSHD_WALLPAPER_ALLOW_HTTP=1` 仅测试机）。
 - 分类页签 = 当前源列表 + 收藏。
 - Desktop 图源 catalog 拉取超时 30 s、单图下载 20 s（`src/main/wallpaper-catalog.js`，2026-08-22 由 8 s 调宽以容纳慢源）；改值须同步本卡。
 - 禁源：Unsplash / Pexels / Pixabay Key、Timeline 登录、R18 开关不进产品。

--- a/docs/handbook/modules/build-release.md
+++ b/docs/handbook/modules/build-release.md
@@ -36,6 +36,7 @@ npm run dist:mac      # macOS 真机
 - `after-pack` 拍平 pnpm 树后，MCP SDK 必须仍能解析到 ajv major ≥ 8（版本冲突的兄弟依赖嵌回 `sdk/node_modules`）；禁止把已安装 runtime 的 `node_modules` 当源码提交。
 - `release.yml` 的 release job 不重跑测试（见 `ci-isolation.test.js`），但发布前**机器校验同一 SHA 的 Desktop tests（test.yml）已绿**，否则拒绝 `gh release create`。先让 main 上该提交 CI 变绿，再打 tag。  
 - macOS 策略（已文档化）：Windows 安装包是发布门槛；macos job 失败时仍发布，但 Release 里不带 `.dmg` 资产。  
+- 下载校验：release job 生成 `SHA512SUMS.txt`（`sha512sum` 标准格式）并随 Release 发布；桌面更新器下载 Setup 后按清单强制校验（缺条目 / 不匹配 / 清单拉取失败均中止并删除下载文件）。**已知限制**：v0.2.7 及更早的 Release 无该清单，安装器不校验直接安装。  
 - 现 `v*` tag 在 CI 绿的前提下 `gh release create`，仍来不及先走验收表。合规顺序见验收表 §0.1。  
 - SQLite 等格式与 rc 版本兼容性以发版说明为准。
 

--- a/docs/handbook/modules/build-release.md
+++ b/docs/handbook/modules/build-release.md
@@ -34,7 +34,9 @@ npm run dist:mac      # macOS 真机
 
 - 验收表：每次发布前对 **CI 安装包 SHA** 走完 [production-acceptance-test-cases.md](../../qa/production-acceptance-test-cases.md)。禁止把源码钉写成已发包装钉；禁止用本机 dist 给该表打 Pass。  
 - `after-pack` 拍平 pnpm 树后，MCP SDK 必须仍能解析到 ajv major ≥ 8（版本冲突的兄弟依赖嵌回 `sdk/node_modules`）；禁止把已安装 runtime 的 `node_modules` 当源码提交。
-- 现 `v*` tag 会立刻 `gh release create`，来不及先走表。合规顺序见验收表 §0.1。  
+- `release.yml` 的 release job 不重跑测试（见 `ci-isolation.test.js`），但发布前**机器校验同一 SHA 的 Desktop tests（test.yml）已绿**，否则拒绝 `gh release create`。先让 main 上该提交 CI 变绿，再打 tag。  
+- macOS 策略（已文档化）：Windows 安装包是发布门槛；macos job 失败时仍发布，但 Release 里不带 `.dmg` 资产。  
+- 现 `v*` tag 在 CI 绿的前提下 `gh release create`，仍来不及先走验收表。合规顺序见验收表 §0.1。  
 - SQLite 等格式与 rc 版本兼容性以发版说明为准。
 
 ## 门槛

--- a/docs/handbook/modules/dsh-home.md
+++ b/docs/handbook/modules/dsh-home.md
@@ -15,9 +15,9 @@
 
 ## 架构要点
 
-`whenReady` 最先 `setDesktopDshHome(userData/dsh-home)` 并建目录，早于 IPC 与 `dsh web`。解析顺序：非空 `DSHD_HOME` → 已绑定路径 → throw。永不回落 `~/.dsh`，也不读环境里的 `DSH_HOME`。
+`whenReady` 最先 `setDesktopDshHome(userData/dsh-home)` 并建目录，早于 IPC 与 `dsh web`。解析顺序：非空 `DSHD_HOME` → 已绑定路径 → throw。永不回落 `~/.dsh`，也不读环境里的 `DSH_HOME`。packaged 构建在 `whenReady` 先 `sanitizePackagedDshHomeEnv`：继承的 `DSHD_HOME` 被丢弃并记日志，除非显式设置 `DSHD_ALLOW_ENV_HOME=1`；dev / 单测不受影响。
 
-`dsh web` 与 `dsh plugin` 的子进程环境覆盖 `DSH_HOME` 为桌面 home。Electron `process.env` 与 PTY **不**写入该值。`DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` 仅在壳层 `baseUrl` 为空或主机为 `api.deepseek.com` 时写入；Ayase 等第三方网关不得别名到这两项。
+`dsh web` 与 `dsh plugin` 的子进程环境覆盖 `DSH_HOME` 为桌面 home。Electron `process.env` 与 PTY **不**写入该值。`DEEPSEEK_API_KEY` / `DEEPSEEK_BASE_URL` 仅在壳层 `baseUrl` 为空或为 `https://api.deepseek.com`（仅 https，明文 http 不别名）时写入；Ayase 等第三方网关不得别名到这两项。
 
 ## 落点
 

--- a/scripts/run-packaged-p0.mjs
+++ b/scripts/run-packaged-p0.mjs
@@ -240,6 +240,8 @@ try {
   const outcome = await run(executable, [`--user-data-dir=${dirs.userData}`, '--no-first-run'], electronSpawnEnv({
     DSH_SMOKE: '1',
     DSH_SMOKE_SIBLING: siblingAbs,
+    // Packaged builds ignore ambient QA/smoke flags; the rehearsal opts in.
+    DSHD_ALLOW_PACKAGED_QA: '1',
   }))
 
   if (!existsSync(dirs.resultPath)) {

--- a/scripts/run-packaged-smoke.mjs
+++ b/scripts/run-packaged-smoke.mjs
@@ -87,6 +87,8 @@ try {
   console.log(`Packaged smoke: ${executable}`)
   const outcome = await run(executable, [`--user-data-dir=${dirs.userData}`, '--no-first-run'], electronSpawnEnv({
     DSH_SMOKE: '1',
+    // Packaged builds ignore ambient QA/smoke flags; the rehearsal opts in.
+    DSHD_ALLOW_PACKAGED_QA: '1',
   }))
 
   if (!existsSync(dirs.resultPath)) {

--- a/src/main/ci-isolation.test.js
+++ b/src/main/ci-isolation.test.js
@@ -97,10 +97,23 @@ test('release workflow builds artifacts without repeating quality or viewport-de
   assert.match(yml, /npm run dist:mac\b/);
 });
 
-test('release.yml still publishes when Windows succeeds and macOS fails', () => {
+test('release job requires a green same-SHA Desktop tests run before publishing', () => {
+  const yml = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
+  const gateAt = yml.indexOf('actions/workflows/test.yml/runs?head_sha=');
+  const publishAt = yml.indexOf('gh release create');
+  assert.ok(gateAt >= 0, 'release.yml must query the test workflow for this SHA');
+  assert.match(yml, /status=success/);
+  assert.match(yml, /actions: read/);
+  assert.ok(publishAt > gateAt, 'the CI gate must run before gh release create');
+});
+
+test('release.yml still publishes when Windows succeeds and macOS fails (documented policy)', () => {
   const yml = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
   assert.match(yml, /always\(\)/);
   assert.match(yml, /needs\.windows\.result == 'success'/);
+  // The policy stays documented next to the if: guard: mac assets are simply
+  // absent when the macos job fails; Windows gates the release.
+  assert.match(yml, /macOS is\n\s*# best-effort/);
 });
 
 test('test workflow keeps portable quality gates without the viewport-dependent smoke', () => {

--- a/src/main/data-import.js
+++ b/src/main/data-import.js
@@ -5,11 +5,14 @@ const os = require('os');
 const path = require('path');
 const { getDesktopDshHome, tryGetDesktopDshHome } = require('../shared/dsh-home');
 const { DROPPED, OFFICIAL_TEMPLATE_BUNDLES, listInstalledPlugins } = require('./plugins');
+const { isValidGithubSpec, isValidPackageName } = require('../host/install-dsh-plugin-client');
 
 const SESSION_LOG = /^session\.jsonl(\.zstd)?$/i;
 const UNSUPPORTED_DB = /\.db$/i;
 const PATH_TRAVERSAL = /(^|[\\/])\.\.([\\/]|$)/;
 const LOCAL_SPEC = /^(file:|link:|workspace:)/i;
+/** Registry semver spec from the official profile manifest (`1.2.3`, `^1.2.3`, `~1.2.3`). */
+const REGISTRY_SEMVER_SPEC = /^[\^~]?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const MCP_FILE = 'mcp-servers.yaml';
 const SKILL_DOC = 'SKILL.md';
 
@@ -114,6 +117,28 @@ function readJson(file) {
   }
 }
 
+/**
+ * Reinstall spec for one manifest row, or null when the row cannot be
+ * reinstalled through a supported channel. Supported channels:
+ * - `github:owner/repo[#ref]` specs (existing marketplace channel);
+ * - registry semver specs, reinstalled as `name@<semver>` (`dsh plugin add`).
+ * Anything else (tarball URLs, git+ URLs, npm aliases, dist-tags) must not
+ * reach `pnpm add`, so the scan pre-marks it `unsupported`.
+ * @param {string} name - manifest dependency name.
+ * @param {string} spec - manifest dependency spec.
+ * @returns {string | null}
+ */
+function pluginReinstallSpec(name, spec) {
+  const value = String(spec || '').trim();
+  if (isValidGithubSpec(value)) {
+    return value;
+  }
+  if (isValidPackageName(name) && REGISTRY_SEMVER_SPEC.test(value)) {
+    return `${name}@${value}`;
+  }
+  return null;
+}
+
 function pluginCandidates(sourceHome) {
   const manifest = readJson(path.join(sourceHome, 'profiles', 'web', 'package.json'));
   const dependencies = manifest?.dependencies && typeof manifest.dependencies === 'object'
@@ -128,7 +153,9 @@ function pluginCandidates(sourceHome) {
         ? 'dropped'
         : LOCAL_SPEC.test(value)
           ? 'local-spec'
-          : '';
+          : pluginReinstallSpec(name, value) === null
+            ? 'unsupported'
+            : '';
     return {
       name,
       spec: value,
@@ -447,6 +474,98 @@ function writeJournal(file, payload) {
   fs.renameSync(tmp, file);
 }
 
+function readImportJournal(userDataDir) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(journalPath(userDataDir), 'utf8'));
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function removeImportTmpDirs(root) {
+  const removed = [];
+  if (!root || !fs.existsSync(root)) {
+    return removed;
+  }
+  const stack = [root];
+  while (stack.length) {
+    const dir = stack.pop();
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const abs = path.join(dir, entry.name);
+      if (entry.name.endsWith('.import-tmp')) {
+        try {
+          fs.rmSync(abs, { recursive: true, force: true });
+          removed.push(abs);
+        } catch {
+          // Leftover staging dirs that cannot be removed stay harmless: the
+          // next copyDirAtomic clears its own target tmp before copying.
+        }
+        continue;
+      }
+      stack.push(abs);
+    }
+  }
+  return removed.sort();
+}
+
+function samePath(left, right) {
+  const a = path.resolve(String(left || ''));
+  const b = path.resolve(String(right || ''));
+  return process.platform === 'win32' ? a.toLowerCase() === b.toLowerCase() : a === b;
+}
+
+/**
+ * Consume a `phase: 'copying'` journal left behind by a crash mid-import:
+ * remove stale `.import-tmp` staging dirs under the desktop home (sessions,
+ * skills, and the attachments staging dir) and mark the journal `recovered`
+ * so the launcher can tell the user to re-run the idempotent, conflict-
+ * skipping import. Only the journal's own destHome is cleaned, and only when
+ * it matches the resolved desktop home; official sources are never touched.
+ * @param {{ userDataDir?: string, destHome?: string }} [options]
+ * @returns {{ recovered: boolean, removedTmp: string[] }}
+ */
+function recoverInterruptedImport({ userDataDir, destHome: dest } = {}) {
+  const target = destHome(dest);
+  const journalDir = userDataDir || path.join(target, '..');
+  const journal = readImportJournal(journalDir);
+  if (!journal || journal.phase !== 'copying') {
+    return { recovered: false, removedTmp: [] };
+  }
+  if (!samePath(journal.destHome, target)) {
+    return { recovered: false, removedTmp: [] };
+  }
+  const removedTmp = [
+    ...removeImportTmpDirs(path.join(target, 'sessions')),
+    ...removeImportTmpDirs(path.join(target, 'skills')),
+  ];
+  const attachmentsTmp = path.join(target, 'attachments.import-tmp');
+  if (fs.existsSync(attachmentsTmp)) {
+    try {
+      fs.rmSync(attachmentsTmp, { recursive: true, force: true });
+      removedTmp.push(attachmentsTmp);
+    } catch {
+      // Same as above: a stuck staging dir does not block the re-run.
+    }
+  }
+  writeJournal(journalPath(journalDir), {
+    ...journal,
+    phase: 'recovered',
+    recoveredAt: new Date().toISOString(),
+    removedTmp,
+  });
+  return { recovered: true, removedTmp };
+}
+
 function copyDirAtomic(from, to) {
   fs.mkdirSync(path.dirname(to), { recursive: true });
   const tmp = `${to}.import-tmp`;
@@ -556,9 +675,11 @@ async function importPlugins({
       results.push({ name: row.name, status: 'skipped', reason: 'installed' });
       continue;
     }
-    const spec = LOCAL_SPEC.test(row.spec)
-      ? row.name
-      : (row.spec && !row.spec.startsWith('^') && !row.spec.startsWith('~') ? row.spec : row.name);
+    const spec = pluginReinstallSpec(row.name, row.spec);
+    if (spec === null) {
+      results.push({ name: row.name, status: 'skipped', reason: 'unsupported' });
+      continue;
+    }
     try {
       const installed = await run(spec);
       results.push({
@@ -722,6 +843,9 @@ module.exports = {
   shouldHoldForImport,
   importSessions,
   importPlugins,
+  pluginReinstallSpec,
+  recoverInterruptedImport,
+  readImportJournal,
   runImport,
   journalPath,
   SESSION_LOG,

--- a/src/main/data-import.test.js
+++ b/src/main/data-import.test.js
@@ -26,6 +26,10 @@ function makeTree() {
       '@deepseek-ai/dsh-base': '1.0.0',
       'good-plugin': 'github:acme/good',
       'file-plugin': 'file:../local',
+      'registry-plugin': '1.2.3',
+      'caret-plugin': '^2.0.0',
+      'tarball-plugin': 'https://example.test/x.tgz',
+      'tag-plugin': 'latest',
     },
   }));
   fs.mkdirSync(userData, { recursive: true });
@@ -75,7 +79,26 @@ test('scanImport lists sessions, skips sqlite, and flags dest conflicts', () => 
   assert.equal(plugins['@deepseek-ai/dsh-base'].skipped, true);
   assert.equal(plugins['file-plugin'].reason, 'local-spec');
   assert.equal(plugins['good-plugin'].skipped, false);
+  assert.equal(plugins['registry-plugin'].skipped, false);
+  assert.equal(plugins['caret-plugin'].skipped, false);
+  assert.equal(plugins['tarball-plugin'].reason, 'unsupported');
+  assert.equal(plugins['tag-plugin'].reason, 'unsupported');
   fs.rmSync(tree.root, { recursive: true, force: true });
+});
+
+test('pluginReinstallSpec maps github and registry semver specs and rejects everything else', () => {
+  const { pluginReinstallSpec } = require('./data-import');
+  assert.equal(pluginReinstallSpec('x', 'github:acme/good'), 'github:acme/good');
+  assert.equal(pluginReinstallSpec('x', 'github:acme/good#abc1234'), 'github:acme/good#abc1234');
+  assert.equal(pluginReinstallSpec('registry-plugin', '1.2.3'), 'registry-plugin@1.2.3');
+  assert.equal(pluginReinstallSpec('@scope/name', '^2.0.0'), '@scope/name@^2.0.0');
+  assert.equal(pluginReinstallSpec('tilde', '~0.4.1-rc.1'), 'tilde@~0.4.1-rc.1');
+  assert.equal(pluginReinstallSpec('x', 'https://example.test/x.tgz'), null);
+  assert.equal(pluginReinstallSpec('x', 'latest'), null);
+  assert.equal(pluginReinstallSpec('x', 'npm:alias@1.2.3'), null);
+  assert.equal(pluginReinstallSpec('x', 'git+https://github.com/a/b.git'), null);
+  assert.equal(pluginReinstallSpec('../escape', '1.2.3'), null);
+  assert.equal(pluginReinstallSpec('x', ''), null);
 });
 
 test('shouldHoldForImport is true only when dest sessions are empty and source has data', () => {
@@ -128,6 +151,61 @@ test('importSessions rejects relative escape paths', () => {
   fs.rmSync(tree.root, { recursive: true, force: true });
 });
 
+test('recoverInterruptedImport consumes a copying journal and clears .import-tmp staging dirs', () => {
+  const tree = makeTree();
+  const { recoverInterruptedImport, readImportJournal, journalPath } = require('./data-import');
+  fs.mkdirSync(path.join(tree.dest, 'sessions', 'proj', 'sess-a.import-tmp'), { recursive: true });
+  fs.writeFileSync(path.join(tree.dest, 'sessions', 'proj', 'sess-a.import-tmp', 'session.jsonl'), 'partial');
+  fs.mkdirSync(path.join(tree.dest, 'skills', 'alpha.import-tmp'), { recursive: true });
+  fs.mkdirSync(path.join(tree.dest, 'attachments.import-tmp'), { recursive: true });
+  fs.mkdirSync(path.join(tree.dest, 'sessions', 'proj', 'sess-keep'), { recursive: true });
+  fs.writeFileSync(journalPath(tree.userData), `${JSON.stringify({
+    phase: 'copying',
+    sourceHome: tree.source,
+    destHome: tree.dest,
+    items: [],
+  })}\n`);
+  const result = recoverInterruptedImport({ userDataDir: tree.userData, destHome: tree.dest });
+  assert.equal(result.recovered, true);
+  assert.equal(result.removedTmp.length, 3);
+  assert.equal(fs.existsSync(path.join(tree.dest, 'sessions', 'proj', 'sess-a.import-tmp')), false);
+  assert.equal(fs.existsSync(path.join(tree.dest, 'skills', 'alpha.import-tmp')), false);
+  assert.equal(fs.existsSync(path.join(tree.dest, 'attachments.import-tmp')), false);
+  assert.equal(fs.existsSync(path.join(tree.dest, 'sessions', 'proj', 'sess-keep')), true);
+  assert.equal(readImportJournal(tree.userData).phase, 'recovered');
+  const again = recoverInterruptedImport({ userDataDir: tree.userData, destHome: tree.dest });
+  assert.equal(again.recovered, false);
+  fs.rmSync(tree.root, { recursive: true, force: true });
+});
+
+test('recoverInterruptedImport ignores done journals and foreign destHome journals', () => {
+  const tree = makeTree();
+  const { recoverInterruptedImport, journalPath } = require('./data-import');
+  fs.mkdirSync(path.join(tree.dest, 'sessions', 'stale.import-tmp'), { recursive: true });
+  fs.writeFileSync(journalPath(tree.userData), `${JSON.stringify({
+    phase: 'done',
+    sourceHome: tree.source,
+    destHome: tree.dest,
+  })}\n`);
+  assert.equal(
+    recoverInterruptedImport({ userDataDir: tree.userData, destHome: tree.dest }).recovered,
+    false,
+  );
+  assert.equal(fs.existsSync(path.join(tree.dest, 'sessions', 'stale.import-tmp')), true);
+
+  fs.writeFileSync(journalPath(tree.userData), `${JSON.stringify({
+    phase: 'copying',
+    sourceHome: tree.source,
+    destHome: path.join(tree.root, 'somewhere-else'),
+  })}\n`);
+  assert.equal(
+    recoverInterruptedImport({ userDataDir: tree.userData, destHome: tree.dest }).recovered,
+    false,
+  );
+  assert.equal(fs.existsSync(path.join(tree.dest, 'sessions', 'stale.import-tmp')), true);
+  fs.rmSync(tree.root, { recursive: true, force: true });
+});
+
 test('importPlugins skips templates and local specs, and reinstalls selected names', async () => {
   const tree = makeTree();
   const calls = [];
@@ -140,8 +218,31 @@ test('importPlugins skips templates and local specs, and reinstalls selected nam
       return { ok: true };
     },
   });
-  assert.deepEqual(calls, ['github:acme/good']);
+  assert.deepEqual(calls.sort(), ['caret-plugin@^2.0.0', 'github:acme/good', 'registry-plugin@1.2.3']);
   assert.equal(result.plugins.find((row) => row.name === 'good-plugin').status, 'installed');
+  assert.equal(result.plugins.find((row) => row.name === 'registry-plugin').status, 'installed');
+  assert.equal(result.plugins.find((row) => row.name === 'tarball-plugin'), undefined);
+  fs.rmSync(tree.root, { recursive: true, force: true });
+});
+
+test('importPlugins never sends an unsupported spec to the installer, even when selected', async () => {
+  const tree = makeTree();
+  const calls = [];
+  const { importPlugins } = require('./data-import');
+  const result = await importPlugins({
+    sourceHome: tree.source,
+    destHome: tree.dest,
+    selectedNames: ['tarball-plugin', 'tag-plugin', 'registry-plugin'],
+    installPlugin: async (spec) => {
+      calls.push(spec);
+      return { ok: true };
+    },
+  });
+  assert.deepEqual(calls, ['registry-plugin@1.2.3']);
+  assert.equal(result.plugins.find((row) => row.name === 'tarball-plugin').status, 'skipped');
+  assert.equal(result.plugins.find((row) => row.name === 'tarball-plugin').reason, 'unsupported');
+  assert.equal(result.plugins.find((row) => row.name === 'tag-plugin').reason, 'unsupported');
+  assert.equal(result.ok, true);
   fs.rmSync(tree.root, { recursive: true, force: true });
 });
 

--- a/src/main/git.test.js
+++ b/src/main/git.test.js
@@ -10,6 +10,13 @@ const { COMMIT_TIMEOUT_MS, FETCH_TIMEOUT_MS, GH_TIMEOUT_MS, commitArgs, gitBranc
 const { parseRepositoryNameWithOwnerFromNormalized } = require('./git-pullrequest');
 const { setTextGenerator } = require('./git-generate.js');
 
+// Isolate every git child (direct spawns and module-spawned via gitChildEnv)
+// from the developer's global/system config: url.*.insteadOf rewrites,
+// init.defaultBranch, or hook templates must not leak into these fixtures.
+process.env.GIT_CONFIG_GLOBAL = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-git-isolation-')), 'gitconfig');
+fs.writeFileSync(process.env.GIT_CONFIG_GLOBAL, '');
+process.env.GIT_CONFIG_NOSYSTEM = '1';
+
 function makeTempDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-git-'));
   // Pin the workspace authority so cwd checks pass inside this test root.

--- a/src/main/harness-extract.js
+++ b/src/main/harness-extract.js
@@ -151,25 +151,36 @@ async function ensurePackagedHarness(log = () => {}) {
   }
   const dest = extractedHarnessRoot();
   const archive = harnessArchivePath();
-  const identity = fs.existsSync(archive)
+  const loose = looseHarnessRoot();
+  const archiveExists = fs.existsSync(archive);
+  // readPackagedPin throws on a missing/invalid pin before anything on disk
+  // is deleted; a broken install must not destroy a usable runtime.
+  const identity = archiveExists
     ? packagedRuntimeIdentity(readPackagedPin(), fs.statSync(archive).size)
     : null;
   if (identity && canReuseExtractedHarness(dest, identity)) {
     return dest;
   }
+  if (!archiveExists) {
+    // Degraded install (archive stripped or corrupted away). Never delete a
+    // runtime we cannot re-create: reuse what still boots and warn.
+    if (hasBuiltHarness(loose)) {
+      return loose;
+    }
+    if (hasBuiltHarness(dest)) {
+      log('安装包缺少运行时归档 deepseek-harness.tar，降级复用已解压的运行时。建议重新安装。');
+      return dest;
+    }
+    throw new Error('安装包缺少运行时归档 deepseek-harness.tar');
+  }
+  // The archive exists and the extract is stale or incomplete: only now is a
+  // re-extract guaranteed possible, so deleting dest is safe.
   if (fs.existsSync(dest)) {
     log(hasBuiltHarness(dest) ? '运行时与安装包不一致，正在重新解压…' : '运行时不完整，正在重新解压…');
     fs.rmSync(dest, { recursive: true, force: true });
   }
-  const loose = looseHarnessRoot();
   if (hasBuiltHarness(loose)) {
     return loose;
-  }
-  if (!fs.existsSync(archive)) {
-    throw new Error('安装包缺少运行时归档 deepseek-harness.tar');
-  }
-  if (!identity) {
-    throw new Error('安装包缺少 vendor/harness-upstream.json');
   }
   log('正在解压运行时（仅首次，之后会变快）…');
   fs.mkdirSync(dest, { recursive: true });

--- a/src/main/harness-extract.test.js
+++ b/src/main/harness-extract.test.js
@@ -7,10 +7,11 @@ const os = require('node:os');
 const path = require('node:path');
 const Module = require('node:module');
 
+const electronStub = { app: {} };
 const originalLoad = Module._load;
 Module._load = function load(request, parent, isMain) {
   if (request === 'electron') {
-    return { app: {} };
+    return electronStub;
   }
   return originalLoad.call(this, request, parent, isMain);
 };
@@ -20,8 +21,45 @@ const {
   canReuseExtractedHarness,
   packagedRuntimeIdentity,
   writeRuntimeStamp,
+  ensurePackagedHarness,
 } = require('./harness-extract');
 Module._load = originalLoad;
+
+/**
+ * Point the module at a temp packaged layout: `resources/vendor` for the
+ * archive + pin, `userData/runtime/<version>` for the extract.
+ * @param {import('node:test').TestContext} t
+ * @returns {{ root: string, resources: string, userData: string, dest: string, loose: string, logs: string[] }}
+ */
+function packagedFixture(t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-extract-'));
+  const resources = path.join(root, 'resources');
+  const userData = path.join(root, 'userData');
+  fs.mkdirSync(path.join(resources, 'vendor'), { recursive: true });
+  fs.mkdirSync(userData, { recursive: true });
+  const previousResourcesPath = process.resourcesPath;
+  Object.defineProperty(process, 'resourcesPath', { value: resources, configurable: true });
+  // harness-extract captured electronStub.app by reference at require time,
+  // so the fixture mutates that object instead of replacing it.
+  Object.assign(electronStub.app, {
+    isPackaged: true,
+    getPath: () => userData,
+    getVersion: () => '9.9.9',
+  });
+  t.after(() => {
+    Object.defineProperty(process, 'resourcesPath', { value: previousResourcesPath, configurable: true });
+    for (const key of Object.keys(electronStub.app)) delete electronStub.app[key];
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+  return {
+    root,
+    resources,
+    userData,
+    dest: path.join(userData, 'runtime', '9.9.9'),
+    loose: path.join(resources, 'vendor', 'deepseek-harness'),
+    logs: [],
+  };
+}
 
 function seedBuiltHarness(root) {
   fs.mkdirSync(path.join(root, 'apps', 'cli', 'lib'), { recursive: true });
@@ -137,6 +175,75 @@ test('ensurePackagedHarness reuses only a stamped matching extract', () => {
   assert.match(source, /canReuseExtractedHarness\(dest,/);
   assert.doesNotMatch(
     source,
-    /if \(hasBuiltHarness\(dest\)\) \{\s*return dest;/,
+    /if \(hasBuiltHarness\(dest\)\) \{\s*return dest;\s*\}\s*const loose/,
   );
+});
+
+test('ensurePackagedHarness keeps and reuses a bootable extract when the archive is missing', async (t) => {
+  const fixture = packagedFixture(t);
+  seedBuiltHarness(fixture.dest);
+  const logs = [];
+  const resolved = await ensurePackagedHarness((line) => logs.push(line));
+  assert.equal(resolved, fixture.dest);
+  assert.equal(hasBuiltHarness(fixture.dest), true);
+  assert.match(logs.join('\n'), /降级复用/);
+});
+
+test('ensurePackagedHarness prefers the loose runtime when the archive is missing', async (t) => {
+  const fixture = packagedFixture(t);
+  seedBuiltHarness(fixture.loose);
+  const resolved = await ensurePackagedHarness(() => {});
+  assert.equal(resolved, fixture.loose);
+});
+
+test('ensurePackagedHarness throws without deleting a partial extract when the archive is missing', async (t) => {
+  const fixture = packagedFixture(t);
+  // Partial extract: bin.js only, not a bootable runtime.
+  fs.mkdirSync(path.join(fixture.dest, 'apps', 'cli', 'lib'), { recursive: true });
+  fs.writeFileSync(path.join(fixture.dest, 'apps', 'cli', 'lib', 'bin.js'), 'export {}\n');
+  await assert.rejects(
+    () => ensurePackagedHarness(() => {}),
+    /缺少运行时归档/,
+  );
+  assert.equal(fs.existsSync(path.join(fixture.dest, 'apps', 'cli', 'lib', 'bin.js')), true);
+});
+
+test('ensurePackagedHarness throws before touching the extract when the pin is missing', async (t) => {
+  const fixture = packagedFixture(t);
+  seedBuiltHarness(fixture.dest);
+  fs.writeFileSync(path.join(fixture.resources, 'vendor', 'deepseek-harness.tar'), 'not-a-real-archive');
+  await assert.rejects(
+    () => ensurePackagedHarness(() => {}),
+    /harness-upstream\.json/,
+  );
+  assert.equal(hasBuiltHarness(fixture.dest), true);
+});
+
+test('ensurePackagedHarness re-extracts a stale extract only when the archive exists', async (t) => {
+  const { spawnSync } = require('node:child_process');
+  const fixture = packagedFixture(t);
+  const tree = path.join(fixture.root, 'archive-tree');
+  seedBuiltHarness(tree);
+  const archive = path.join(fixture.resources, 'vendor', 'deepseek-harness.tar');
+  const packed = spawnSync(tarCommand(), ['-cf', archive, '-C', tree, '.'], { windowsHide: true });
+  if (packed.status !== 0) {
+    t.skip('tar unavailable for archive fixture');
+    return;
+  }
+  fs.writeFileSync(
+    path.join(fixture.resources, 'vendor', 'harness-upstream.json'),
+    JSON.stringify({ sha: '528c682e061696f5a160f363f236ecbf53cbd006', npm: '0.1.1-rc.1' }),
+  );
+  // Stale extract: bootable but with no stamp, so it must be replaced.
+  seedBuiltHarness(fixture.dest);
+  fs.writeFileSync(path.join(fixture.dest, 'stale-marker.txt'), 'old');
+  const resolved = await ensurePackagedHarness(() => {});
+  assert.equal(resolved, fixture.dest);
+  assert.equal(hasBuiltHarness(fixture.dest), true);
+  assert.equal(fs.existsSync(path.join(fixture.dest, 'stale-marker.txt')), false);
+  const identity = packagedRuntimeIdentity(
+    { sha: '528c682e061696f5a160f363f236ecbf53cbd006', npm: '0.1.1-rc.1' },
+    fs.statSync(archive).size,
+  );
+  assert.equal(canReuseExtractedHarness(fixture.dest, identity), true);
 });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2,7 +2,7 @@ const { app, dialog, globalShortcut, session } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { loadConfig, saveConfig, REMOTE_FEATURE_ENABLED, parkRemoteSnapshot } = require('./config');
-const { setDesktopDshHome, desktopDshHomeFromUserData, tryGetDesktopDshHome } = require('../shared/dsh-home');
+const { setDesktopDshHome, desktopDshHomeFromUserData, tryGetDesktopDshHome, sanitizePackagedDshHomeEnv } = require('../shared/dsh-home');
 const { DshManager, ensureOwnedPort } = require('./dsh');
 const { HarnessController } = require('./harness-controller');
 const { stripDroppedPlugins, healDanglingBundles, ensureDesktopInstallPlugin, applyDisabledBundles } = require('./plugins');
@@ -1101,6 +1101,10 @@ if (!gotLock) {
   app.setAppUserModelId('ai.deepseek.harness.gui');
 
   app.whenReady().then(async () => {
+    const homeEnv = sanitizePackagedDshHomeEnv({ isPackaged: app.isPackaged });
+    if (homeEnv.dropped) {
+      dsh.log(`忽略继承的 DSHD_HOME=${homeEnv.value}（packaged 下需要 DSHD_ALLOW_ENV_HOME=1）`, 'app');
+    }
     const desktopHome = setDesktopDshHome(desktopDshHomeFromUserData(app.getPath('userData')));
     fs.mkdirSync(desktopHome, { recursive: true });
     dsh.log(`Harness 家目录 ${desktopHome}`, 'app');

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -47,11 +47,12 @@ const {
 } = require('./window');
 const { showClosingOverlay } = require('./closing-overlay');
 const { hideOnClose } = require('./close-behavior');
-const { runReleaseUiWalk, connectConfiguredWorkspace, makeRecorder } = require('./release-ui-walk');
-const { runComposerOfficialQa } = require('./composer-official-qa');
-const { runAppendixAQa } = require('./appendix-a-qa');
-const { runShellP0Qa, runPersistQa, runRecoveryQa } = require('./shell-p0-qa');
-const { runPackagedP0 } = require('./packaged-p0');
+const { qaFlag } = require('./qa-gate');
+
+/** Packaged-gated QA flag (see qa-gate.js). */
+function qaEnv(name) {
+  return qaFlag(name, { isPackaged: app.isPackaged });
+}
 
 const dsh = new DshManager();
 const remote = new RemoteGateway({
@@ -644,6 +645,12 @@ async function probeThemeBackgrounds(wc) {
 
 /** One-shot launch smoke: report the assembled chrome and exit with its status. */
 async function runSmoke(win) {
+  // QA drivers are loaded lazily: they never stay resident in a production
+  // main process that did not enter the smoke path.
+  const { runReleaseUiWalk, connectConfiguredWorkspace, makeRecorder } = require('./release-ui-walk');
+  const { runComposerOfficialQa } = require('./composer-official-qa');
+  const { runAppendixAQa } = require('./appendix-a-qa');
+  const { runShellP0Qa, runPersistQa, runRecoveryQa } = require('./shell-p0-qa');
   const pageErrors = [];
   const exitSmoke = async (code) => {
     await Promise.allSettled([
@@ -784,6 +791,7 @@ async function runSmoke(win) {
       : '';
     if (siblingPath) {
       try {
+        const { runPackagedP0 } = require('./packaged-p0');
         const config = loadConfig();
         packagedP0 = await runPackagedP0({
           siblingPath,
@@ -808,12 +816,13 @@ async function runSmoke(win) {
       }));
     }
     let qaAttached = false;
-    const needsComposerQa = process.env.DSH_QA_COMPOSER === '1';
-    const needsReleaseQa = process.env.DSH_QA === '1';
-    const needsAppendixQa = process.env.DSH_QA_APPENDIX === '1';
-    const needsShellQa = process.env.DSH_QA_SHELL === '1';
-    const needsPersistQa = process.env.DSH_QA_PERSIST === '1';
-    const needsRecoveryQa = process.env.DSH_QA_RECOVERY === '1';
+    const needsComposerQa = qaEnv('DSH_QA_COMPOSER');
+    const needsReleaseQa = qaEnv('DSH_QA');
+    const needsAppendixQa = qaEnv('DSH_QA_APPENDIX');
+    const needsShellQa = qaEnv('DSH_QA_SHELL');
+    const needsPersistQa = qaEnv('DSH_QA_PERSIST');
+    const needsRecoveryQa = qaEnv('DSH_QA_RECOVERY');
+    const needsThemeSmoke = qaEnv('DSH_THEME_SMOKE');
     if (needsReleaseQa || needsComposerQa || needsAppendixQa || needsShellQa || needsPersistQa) {
       if (!wc.debugger.isAttached()) {
         await wc.debugger.attach('1.3');
@@ -1002,7 +1011,7 @@ async function runSmoke(win) {
         // Detach is best-effort before process exit.
       }
     }
-    if (process.env.DSH_THEME_SMOKE === '1') {
+    if (needsThemeSmoke) {
       try {
         result.themeSmoke = await probeThemeBackgrounds(wc);
       } catch (error) {
@@ -1029,14 +1038,14 @@ async function runSmoke(win) {
       && titlebarHits.hits.git > 0
       && titlebarHits.error == null
       && ptyStatus === 'echoed:ok'
-      && (process.env.DSH_THEME_SMOKE !== '1' || result.themeSmoke?.ok === true)
-      && (process.env.DSH_QA !== '1' || result.qa?.ok === true)
-      && (process.env.DSH_QA_COMPOSER !== '1' || result.composerOfficialQa?.ok === true)
-      && (process.env.DSH_QA_APPENDIX !== '1' || result.appendixQa?.ok === true)
-      && (process.env.DSH_QA_SHELL !== '1' || result.shellP0Qa?.ok === true)
-      && (process.env.DSH_QA_PERSIST !== '1' || result.persistQa?.ok === true)
-      && (process.env.DSH_QA_RECOVERY !== '1' || result.recoveryQa?.ok === true)
-      && (process.env.DSH_QA_RECOVERY === '1' || pageErrors.length === 0)
+      && (!needsThemeSmoke || result.themeSmoke?.ok === true)
+      && (!needsReleaseQa || result.qa?.ok === true)
+      && (!needsComposerQa || result.composerOfficialQa?.ok === true)
+      && (!needsAppendixQa || result.appendixQa?.ok === true)
+      && (!needsShellQa || result.shellP0Qa?.ok === true)
+      && (!needsPersistQa || result.persistQa?.ok === true)
+      && (!needsRecoveryQa || result.recoveryQa?.ok === true)
+      && (needsRecoveryQa || pageErrors.length === 0)
       && (!siblingPath || packagedP0?.ok === true);
     try {
       fs.writeFileSync(path.join(app.getPath('userData'), 'dshd-smoke.json'), JSON.stringify({
@@ -1064,7 +1073,7 @@ async function runSmoke(win) {
 }
 
 function quitApp() {
-  if (process.env.DSH_QA_SHELL === '1' && process.env.DSH_QA_ALLOW_QUIT !== '1') {
+  if (qaEnv('DSH_QA_SHELL') && process.env.DSH_QA_ALLOW_QUIT !== '1') {
     qaQuitIntercepted = true;
     console.log('[DSH_QA_SHELL] quit intercepted');
     return;
@@ -1147,7 +1156,7 @@ if (!gotLock) {
 
     await openLauncher();
     await runColdStartGate();
-    if (process.env.DSH_SMOKE === '1') {
+    if (qaEnv('DSH_SMOKE')) {
       if (!getMainWindow()) {
         await startDesktopFromLauncher();
       }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -15,7 +15,7 @@ const { RemoteGateway } = require('./remote');
 const { buildMenu } = require('./menu');
 const { createTray, invokeTrayAction } = require('./tray');
 const { checkUpdate, installUpdate } = require('./update');
-const { scanImport, shouldHoldForImport } = require('./data-import');
+const { scanImport, shouldHoldForImport, recoverInterruptedImport } = require('./data-import');
 const {
   shouldPromptUpdate,
   shouldAutoStartDesktop,
@@ -205,10 +205,21 @@ async function runColdStartGate() {
     }
     updatePromptPending = false;
   }
+  let importRecovery = { recovered: false, removedTmp: [] };
+  try {
+    importRecovery = recoverInterruptedImport({ userDataDir: app.getPath('userData') });
+  } catch (error) {
+    dsh.log(`导入日志恢复失败：${error.message || String(error)}`, 'error');
+  }
   const scan = scanImport();
-  const holdForImport = shouldHoldForImport(scan);
+  const holdForImport = shouldHoldForImport(scan) || importRecovery.recovered;
   if (holdForImport) {
     sendToLauncher('shell:show-tab', { tab: 'import' });
+  }
+  if (importRecovery.recovered) {
+    sendToLauncher('shell:launcher-hint', {
+      importResume: { removedTmp: importRecovery.removedTmp.length },
+    });
   }
   const lastStart = readLastDesktopStart(app.getPath('userData'));
   const lastStartFailed = lastStart.ok === false;

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -17,7 +17,7 @@ const { listThemes, resolveTheme } = require('../shared/themes');
 const { applyAppTheme } = require('./chrome');
 const { checkUpdate, installUpdate, listReleases, installRelease, currentVersion, REPO_URL, RELEASES_PAGE } = require('./update');
 const { listMarketplace } = require('./marketplace-catalog');
-const { listInstalledPlugins, installPlugin, installMarketplacePlugin, uninstallPlugin } = require('./marketplace-install');
+const { listInstalledPlugins, installPlugin, installImportPlugin, installMarketplacePlugin, uninstallPlugin } = require('./marketplace-install');
 const {
   listInstalledPlugins: listProfilePlugins,
   applyDisabledBundles,
@@ -473,7 +473,7 @@ function registerIpc({ dsh, harness, startHarness, startDesktop, remote }) {
       selectedPluginNames: Array.isArray(options.selectedPluginNames) ? options.selectedPluginNames : [],
       selectedMcpIds: Array.isArray(options.selectedMcpIds) ? options.selectedMcpIds : [],
       importAttachments: options.importAttachments === true,
-      installPlugin: (spec) => installPlugin(spec, { token: loadConfig().githubToken }),
+      installPlugin: (spec) => installImportPlugin(spec, { token: loadConfig().githubToken }),
     });
     return {
       ...result,

--- a/src/main/marketplace-install.js
+++ b/src/main/marketplace-install.js
@@ -558,6 +558,56 @@ async function installPlugin(spec, options = {}) {
   });
 }
 
+/** Launcher-import registry spec: `name@1.2.3` / `name@^1.2.3` / `name@~1.2.3`. */
+const IMPORT_REGISTRY_VERSION = /^[\^~]?\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+/**
+ * Split a launcher-import registry spec into `{ name, version }`.
+ * Scoped names keep their leading `@`; the version separator is the last `@`.
+ * @param {string} spec
+ * @returns {{ name: string, version: string } | null}
+ */
+function parseImportRegistrySpec(spec) {
+  const value = String(spec || '').trim();
+  const at = value.lastIndexOf('@');
+  if (at <= 0) {
+    return null;
+  }
+  const name = value.slice(0, at);
+  const version = value.slice(at + 1);
+  if (!isValidPackageName(name) || !IMPORT_REGISTRY_VERSION.test(version)) {
+    return null;
+  }
+  return { name, version };
+}
+
+/**
+ * Launcher-import install channel: reinstall a plugin from the user's own
+ * official profile manifest. Accepts the marketplace `github:` specs plus
+ * pinned registry `name@<semver>` specs. This channel is main-process only
+ * (LAUNCHER IPC); the renderer/tool `installPlugin` channel stays github-only.
+ * @param {string} spec - `github:owner/repo[#ref]` or `name@<semver>`.
+ * @param {{ allowBuilds?: string[], token?: string, onProgress?: Function, runPlugin?: Function }} [options]
+ * @returns {Promise<{ ok: boolean, error?: string, spec?: string, log?: string }>}
+ */
+async function installImportPlugin(spec, options = {}) {
+  const value = String(spec || '').trim();
+  if (!value) {
+    return { ok: false, error: '缺少安装规格' };
+  }
+  const registry = isValidGithubSpec(value) ? null : parseImportRegistrySpec(value);
+  if (!isValidGithubSpec(value) && !registry) {
+    return { ok: false, error: '仅支持 github:owner/repo[#ref] 或 name@版本 安装规格' };
+  }
+  return withPluginLock(async () => {
+    const droppedKey = registry ? registry.name : value;
+    if (DROPPED.includes(droppedKey) || DROPPED.some((item) => droppedKey.includes(item))) {
+      return { ok: false, error: '该插件已退役，不再提供安装' };
+    }
+    return addPluginSpec(value, options);
+  });
+}
+
 async function uninstallPlugin(packageName, options = {}) {
   const name = String(packageName || '').trim();
   if (!name) {
@@ -650,6 +700,8 @@ module.exports = {
   parseAllowBuilds,
   allowBuildsInWorkspace,
   installPlugin,
+  installImportPlugin,
+  parseImportRegistrySpec,
   uninstallPlugin,
   installMarketplacePlugin,
   resolveCli,

--- a/src/main/marketplace-install.test.js
+++ b/src/main/marketplace-install.test.js
@@ -28,6 +28,8 @@ globalThis.fetch = async () => {
 const { parseAllowBuilds } = require('./marketplace-allowbuilds');
 const {
   installPlugin,
+  installImportPlugin,
+  parseImportRegistrySpec,
   uninstallPlugin,
   installMarketplacePlugin,
 } = require('./marketplace-install');
@@ -200,6 +202,59 @@ test('installPlugin rejects invalid allowBuilds before invoking the CLI', async 
   const result = await installPlugin('github:owner/repo', { allowBuilds: ['../prepare'] });
   assert.equal(result.ok, false);
   assert.match(result.error, /allowBuilds/);
+});
+
+test('parseImportRegistrySpec accepts pinned name@semver and rejects loose specs', () => {
+  assert.deepEqual(parseImportRegistrySpec('good-plugin@1.2.3'), { name: 'good-plugin', version: '1.2.3' });
+  assert.deepEqual(
+    parseImportRegistrySpec('@scope/name@^2.0.0-rc.1'),
+    { name: '@scope/name', version: '^2.0.0-rc.1' },
+  );
+  assert.equal(parseImportRegistrySpec('good-plugin'), null);
+  assert.equal(parseImportRegistrySpec('good-plugin@latest'), null);
+  assert.equal(parseImportRegistrySpec('@scope/name'), null);
+  assert.equal(parseImportRegistrySpec('../escape@1.2.3'), null);
+  assert.equal(parseImportRegistrySpec('good plugin@1.2.3'), null);
+  assert.equal(parseImportRegistrySpec(''), null);
+});
+
+test('installImportPlugin adds a registry name@semver spec through the CLI', async () => {
+  const { calls, runPlugin } = recordRunner();
+  const result = await installImportPlugin('good-plugin@1.2.3', { runPlugin });
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [['add', 'good-plugin@1.2.3']]);
+});
+
+test('installImportPlugin still accepts the github channel', async () => {
+  const { calls, runPlugin } = recordRunner();
+  const result = await installImportPlugin('github:acme/good#0123456789abcdef0123456789abcdef01234567', { runPlugin });
+  assert.equal(result.ok, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], 'add');
+});
+
+test('installImportPlugin rejects tarballs, dist-tags, and local specs before the CLI', async () => {
+  const { calls, runPlugin } = recordRunner();
+  for (const spec of [
+    'https://example.test/x.tgz',
+    'good-plugin@latest',
+    'file:../local',
+    'git+https://github.com/a/b.git',
+    'npm:alias@1.2.3',
+    '',
+  ]) {
+    const result = await installImportPlugin(spec, { runPlugin });
+    assert.equal(result.ok, false, `spec should be rejected: ${spec}`);
+  }
+  assert.equal(calls.length, 0);
+});
+
+test('installImportPlugin rejects a DROPPED plugin name before the CLI', async () => {
+  const { calls, runPlugin } = recordRunner();
+  const result = await installImportPlugin('@dsh-external/dsh-genui@1.0.0', { runPlugin });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /退役/);
+  assert.equal(calls.length, 0);
 });
 
 test('uninstallPlugin rejects shell syntax before invoking the CLI', async () => {

--- a/src/main/qa-gate.js
+++ b/src/main/qa-gate.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * Gate for the QA / smoke drivers (`DSH_SMOKE`, `DSH_QA*`, `DSH_THEME_SMOKE`).
+ * These drivers attach a debugger, resize windows, intercept quit, and call
+ * app.exit — none of that may run in an installed production app just because
+ * an ambient environment variable is set. Packaged builds therefore require
+ * the explicit extra switch `DSHD_ALLOW_PACKAGED_QA=1`, which only the
+ * repository's own `qa:packaged` / `smoke:packaged` rehearsal scripts set.
+ * Source runs (development, CI) keep the old single-variable behavior.
+ */
+
+/**
+ * Whether QA drivers may run at all in this process.
+ * @param {{ isPackaged?: boolean, env?: NodeJS.ProcessEnv }} [options]
+ * @returns {boolean}
+ */
+function qaDriversAllowed({ isPackaged = false, env = process.env } = {}) {
+  if (!isPackaged) {
+    return true;
+  }
+  return env.DSHD_ALLOW_PACKAGED_QA === '1';
+}
+
+/**
+ * Read one QA flag (`=== '1'`), honoring the packaged gate.
+ * @param {string} name - environment variable name (e.g. `DSH_QA_SHELL`).
+ * @param {{ isPackaged?: boolean, env?: NodeJS.ProcessEnv }} [options]
+ * @returns {boolean}
+ */
+function qaFlag(name, { isPackaged = false, env = process.env } = {}) {
+  if (env[name] !== '1') {
+    return false;
+  }
+  return qaDriversAllowed({ isPackaged, env });
+}
+
+module.exports = {
+  qaDriversAllowed,
+  qaFlag,
+};

--- a/src/main/qa-gate.test.js
+++ b/src/main/qa-gate.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { qaDriversAllowed, qaFlag } = require('./qa-gate');
+
+test('source runs honor QA flags without an extra switch', () => {
+  assert.equal(qaDriversAllowed({ isPackaged: false, env: {} }), true);
+  assert.equal(qaFlag('DSH_QA', { isPackaged: false, env: { DSH_QA: '1' } }), true);
+  assert.equal(qaFlag('DSH_QA', { isPackaged: false, env: {} }), false);
+  assert.equal(qaFlag('DSH_QA', { isPackaged: false, env: { DSH_QA: 'yes' } }), false);
+});
+
+test('packaged runs ignore ambient QA flags unless DSHD_ALLOW_PACKAGED_QA=1', () => {
+  assert.equal(qaDriversAllowed({ isPackaged: true, env: {} }), false);
+  assert.equal(qaFlag('DSH_QA_SHELL', { isPackaged: true, env: { DSH_QA_SHELL: '1' } }), false);
+  assert.equal(qaFlag('DSH_SMOKE', { isPackaged: true, env: { DSH_SMOKE: '1' } }), false);
+  assert.equal(
+    qaFlag('DSH_QA_SHELL', {
+      isPackaged: true,
+      env: { DSH_QA_SHELL: '1', DSHD_ALLOW_PACKAGED_QA: '1' },
+    }),
+    true,
+  );
+});
+
+test('index.js consumes QA env only through the gate and loads QA drivers lazily', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'index.js'), 'utf8');
+  // No top-level (column-0) requires of the QA driver modules: they must not
+  // ship resident in the production main process.
+  for (const mod of [
+    'release-ui-walk',
+    'composer-official-qa',
+    'appendix-a-qa',
+    'shell-p0-qa',
+    'packaged-p0',
+  ]) {
+    assert.doesNotMatch(
+      source,
+      new RegExp(`^const .*require\\('\\./${mod}'\\)`, 'm'),
+      `${mod} must be required lazily inside the smoke path`,
+    );
+    assert.match(source, new RegExp(`require\\('\\./${mod}'\\)`));
+  }
+  // Raw env reads of the QA flags would bypass the packaged gate.
+  assert.doesNotMatch(source, /process\.env\.DSH_QA[A-Z_]*\s*===\s*'1'/);
+  assert.doesNotMatch(source, /process\.env\.DSH_SMOKE\s*===\s*'1'/);
+  assert.doesNotMatch(source, /process\.env\.DSH_THEME_SMOKE\s*===\s*'1'/);
+  assert.match(source, /require\('\.\/qa-gate'\)/);
+});
+
+test('packaged QA rehearsal scripts opt in explicitly', () => {
+  const root = path.join(__dirname, '..', '..');
+  for (const script of ['run-packaged-smoke.mjs', 'run-packaged-p0.mjs']) {
+    const source = fs.readFileSync(path.join(root, 'scripts', script), 'utf8');
+    assert.match(source, /DSHD_ALLOW_PACKAGED_QA/, `${script} must set the packaged QA switch`);
+  }
+});

--- a/src/main/remote.js
+++ b/src/main/remote.js
@@ -80,7 +80,11 @@ function shouldGzipProxy(headers, contentType) {
   return /javascript|text\/html|text\/css|image\/svg/i.test(String(contentType || ''));
 }
 
-/** Startup remote face: never listens and never creates an HTTP server. */
+/**
+ * Never-listening remote face. Production always constructs `RemoteGateway`
+ * (`remote.test.js` asserts index.js does not use this); the export stays as
+ * a test stub for the fail-closed IPC paths in `ipc.test.js` / `remote.test.js`.
+ */
 function createDisabledRemote() {
   const snapshot = () => ({
     available: false,

--- a/src/main/update.js
+++ b/src/main/update.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const fs = require('fs');
 const https = require('https');
 const path = require('path');
@@ -14,6 +15,12 @@ const REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
 const CHECK_TIMEOUT_MS = 10_000;
 /** Whole-download budget for one Setup asset (hundreds of MB on slow links). */
 const DOWNLOAD_TIMEOUT_MS = 15 * 60_000;
+/**
+ * Release asset with `sha512sum` lines for every installer. Releases that
+ * carry it get mandatory post-download verification; older releases without
+ * it install unverified (documented limitation, not an error).
+ */
+const CHECKSUM_ASSET_NAME = 'SHA512SUMS.txt';
 
 function currentVersion() {
   try {
@@ -61,6 +68,75 @@ function pickInstaller(assets) {
     || exes.find((asset) => !/portable/i.test(asset.name))
     || exes[0]
     || null;
+}
+
+function pickChecksumAsset(assets) {
+  const list = Array.isArray(assets) ? assets : [];
+  return list.find((asset) => typeof asset?.name === 'string'
+    && asset.name.toLowerCase() === CHECKSUM_ASSET_NAME.toLowerCase()
+    && typeof asset.browser_download_url === 'string') || null;
+}
+
+/**
+ * Parse `sha512sum` output: one `<128-hex>  <filename>` line per asset
+ * (`*` binary-mode marker tolerated).
+ * @param {string} text
+ * @returns {Map<string, string>} filename -> lower-case hex digest
+ */
+function parseSha512Sums(text) {
+  const sums = new Map();
+  for (const line of String(text || '').split(/\r?\n/)) {
+    const match = line.match(/^([0-9a-fA-F]{128})\s+\*?(.+?)\s*$/);
+    if (match) {
+      sums.set(match[2], match[1].toLowerCase());
+    }
+  }
+  return sums;
+}
+
+function sha512HexOfFile(file) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('sha512');
+    const stream = fs.createReadStream(file);
+    stream.on('error', reject);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolve(hash.digest('hex')));
+  });
+}
+
+/**
+ * Mandatory verification once a release carries SHA512SUMS.txt: any failure
+ * (manifest fetch, missing entry, digest mismatch) throws so the installer
+ * is never launched from a partial or tampered download.
+ * @param {string} dest - downloaded installer path.
+ * @param {string} assetName - original release asset name (manifest key).
+ * @param {string} checksumUrl - browser_download_url of SHA512SUMS.txt.
+ */
+async function verifyAssetChecksum(dest, assetName, checksumUrl) {
+  let response;
+  try {
+    response = await fetch(checksumUrl, {
+      headers: downloadHeaders(true),
+      signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      throw new Error('校验清单下载超时');
+    }
+    throw new Error(`校验清单下载失败：${error.message || String(error)}`);
+  }
+  if (!response.ok) {
+    throw new Error(`校验清单下载失败（${response.status}）`);
+  }
+  const sums = parseSha512Sums(await response.text());
+  const expected = sums.get(assetName);
+  if (!expected) {
+    throw new Error(`校验清单缺少 ${assetName} 的条目`);
+  }
+  const actual = await sha512HexOfFile(dest);
+  if (actual !== expected) {
+    throw new Error('安装包校验失败（sha512 不匹配），已删除下载文件');
+  }
 }
 
 function isTimeoutError(error) {
@@ -114,6 +190,7 @@ async function checkUpdate() {
     }
     const latest = normalizeVersion(release.tag_name || release.name);
     const asset = pickInstaller(release.assets);
+    const checksum = pickChecksumAsset(release.assets);
     const newer = latest && compareVersions(latest, currentVersion()) > 0;
     return snapshot({
       status: newer ? 'available' : 'current',
@@ -123,6 +200,7 @@ async function checkUpdate() {
       notes: typeof release.body === 'string' ? release.body : '',
       assetName: asset?.name || '',
       assetUrl: asset?.browser_download_url || '',
+      checksumUrl: checksum?.browser_download_url || '',
     });
   } catch (error) {
     return snapshot({
@@ -241,6 +319,7 @@ function summarizeRelease(release, current) {
     return null;
   }
   const asset = pickInstaller(release.assets);
+  const checksum = pickChecksumAsset(release.assets);
   const version = normalizeVersion(release.tag_name || release.name);
   return {
     tag: release.tag_name || '',
@@ -252,6 +331,7 @@ function summarizeRelease(release, current) {
     newer: Boolean(version) && compareVersions(version, current) > 0,
     assetName: asset?.name || '',
     assetUrl: asset?.browser_download_url || '',
+    checksumUrl: checksum?.browser_download_url || '',
     installable: Boolean(asset),
   };
 }
@@ -288,6 +368,14 @@ async function installFromAsset(info, onProgress) {
   const safeName = path.basename(info.assetName || 'DeepSeek-Harness-Setup.exe').replace(/[^\w.\-]+/g, '_');
   const dest = path.join(dir, safeName);
   await downloadFile(info.assetUrl, dest, onProgress);
+  if (info.checksumUrl) {
+    try {
+      await verifyAssetChecksum(dest, info.assetName, info.checksumUrl);
+    } catch (error) {
+      cleanupPartial(dest);
+      throw error;
+    }
+  }
   if (typeof onProgress === 'function') {
     onProgress({ phase: 'install', percent: 100 });
   }
@@ -336,6 +424,7 @@ async function installUpdate(onProgress) {
     ...info,
     assetUrl: info.assetUrl,
     assetName: info.assetName,
+    checksumUrl: info.checksumUrl,
     htmlUrl: info.htmlUrl,
   }, onProgress);
 }
@@ -347,6 +436,7 @@ module.exports = {
   RELEASES_PAGE,
   CHECK_TIMEOUT_MS,
   DOWNLOAD_TIMEOUT_MS,
+  CHECKSUM_ASSET_NAME,
   currentVersion,
   checkUpdate,
   installUpdate,
@@ -354,4 +444,6 @@ module.exports = {
   listReleases,
   installRelease,
   downloadFile,
+  parseSha512Sums,
+  verifyAssetChecksum,
 };

--- a/src/main/update.js
+++ b/src/main/update.js
@@ -10,6 +10,10 @@ const RELEASES_LATEST = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_R
 const RELEASES_LIST = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases?per_page=30`;
 const RELEASES_PAGE = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/releases`;
 const REPO_URL = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}`;
+/** API check budget: a hung GitHub must not stall the cold-start gate. */
+const CHECK_TIMEOUT_MS = 10_000;
+/** Whole-download budget for one Setup asset (hundreds of MB on slow links). */
+const DOWNLOAD_TIMEOUT_MS = 15 * 60_000;
 
 function currentVersion() {
   try {
@@ -59,8 +63,24 @@ function pickInstaller(assets) {
     || null;
 }
 
-async function githubJson(url) {
-  const response = await fetch(url, { headers: githubHeaders() });
+function isTimeoutError(error) {
+  return error instanceof Error
+    && (error.name === 'TimeoutError' || error.name === 'AbortError');
+}
+
+async function githubJson(url, timeoutMs = CHECK_TIMEOUT_MS) {
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: githubHeaders(),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      throw new Error(`GitHub 请求超时（${Math.round(timeoutMs / 1000)}s）`);
+    }
+    throw error;
+  }
   if (response.status === 404) {
     return null;
   }
@@ -135,18 +155,30 @@ function cleanupPartial(dest) {
   }
 }
 
-function downloadFile(url, dest, onProgress) {
+function downloadFile(url, dest, onProgress, { timeoutMs = DOWNLOAD_TIMEOUT_MS } = {}) {
   return new Promise((resolve, reject) => {
     const file = fs.createWriteStream(dest);
     let settled = false;
+    let activeRequest = null;
     const fail = (error) => {
       if (settled) {
         return;
       }
       settled = true;
-      file.close(() => cleanupPartial(dest));
-      reject(error);
+      clearTimeout(deadline);
+      if (activeRequest) {
+        activeRequest.destroy();
+      }
+      file.close(() => {
+        cleanupPartial(dest);
+        reject(error);
+      });
     };
+    // One wall-clock budget for the whole download (all redirect hops): a
+    // stalled connection must not park the launcher on "下载 0%" forever.
+    const deadline = setTimeout(() => {
+      fail(new Error(`下载超时（${Math.round(timeoutMs / 60_000)} 分钟）`));
+    }, timeoutMs);
     const visit = (target, hops) => {
       if (hops > 8) {
         fail(new Error('Too many redirects'));
@@ -183,9 +215,11 @@ function downloadFile(url, dest, onProgress) {
             return;
           }
           settled = true;
+          clearTimeout(deadline);
           file.close(() => resolve(dest));
         });
       });
+      activeRequest = request;
       request.on('error', fail);
     };
     file.on('error', fail);
@@ -311,10 +345,13 @@ module.exports = {
   GITHUB_REPO,
   REPO_URL,
   RELEASES_PAGE,
+  CHECK_TIMEOUT_MS,
+  DOWNLOAD_TIMEOUT_MS,
   currentVersion,
   checkUpdate,
   installUpdate,
   summarizeRelease,
   listReleases,
   installRelease,
+  downloadFile,
 };

--- a/src/main/update.test.js
+++ b/src/main/update.test.js
@@ -7,7 +7,17 @@ const os = require('node:os');
 const path = require('node:path');
 const https = require('node:https');
 const { EventEmitter } = require('node:events');
-const { summarizeRelease, installRelease, checkUpdate, listReleases, downloadFile } = require('./update');
+const crypto = require('node:crypto');
+const {
+  summarizeRelease,
+  installRelease,
+  checkUpdate,
+  listReleases,
+  downloadFile,
+  parseSha512Sums,
+  verifyAssetChecksum,
+  CHECKSUM_ASSET_NAME,
+} = require('./update');
 
 test('summarizeRelease skips drafts and marks a missing installer', () => {
   assert.equal(summarizeRelease({ draft: true, tag_name: 'v0.2.7' }, '0.2.6'), null);
@@ -89,6 +99,73 @@ test('downloadFile fails, aborts the request, and removes the partial after the 
     assert.equal(fs.existsSync(dest), false);
   } finally {
     https.get = previousGet;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('summarizeRelease exposes the SHA512SUMS.txt checksum manifest when present', () => {
+  const listed = summarizeRelease({
+    draft: false,
+    tag_name: 'v0.2.8',
+    assets: [
+      { name: 'Deepseek-Harness-Desktop-Setup-0.2.8.exe', browser_download_url: 'https://example.test/setup.exe' },
+      { name: CHECKSUM_ASSET_NAME, browser_download_url: 'https://example.test/SHA512SUMS.txt' },
+    ],
+  }, '0.2.7');
+  assert.equal(listed.checksumUrl, 'https://example.test/SHA512SUMS.txt');
+  const withoutManifest = summarizeRelease({
+    draft: false,
+    tag_name: 'v0.2.6',
+    assets: [{ name: 'Deepseek-Harness-Desktop-Setup-0.2.6.exe', browser_download_url: 'https://example.test/setup.exe' }],
+  }, '0.2.7');
+  assert.equal(withoutManifest.checksumUrl, '');
+});
+
+test('parseSha512Sums reads sha512sum lines and ignores garbage', () => {
+  const hexA = 'a'.repeat(128);
+  const hexB = 'B'.repeat(128);
+  const sums = parseSha512Sums([
+    `${hexA}  Deepseek-Harness-Desktop-Setup-0.2.8.exe`,
+    `${hexB} *Deepseek-Harness-Desktop-0.2.8-mac-arm64.dmg`,
+    'not a checksum line',
+    'deadbeef  short-hash.exe',
+    '',
+  ].join('\n'));
+  assert.equal(sums.get('Deepseek-Harness-Desktop-Setup-0.2.8.exe'), hexA);
+  assert.equal(sums.get('Deepseek-Harness-Desktop-0.2.8-mac-arm64.dmg'), 'b'.repeat(128));
+  assert.equal(sums.size, 2);
+});
+
+test('verifyAssetChecksum passes a good digest and rejects mismatch or missing entry', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-update-sum-'));
+  const dest = path.join(dir, 'setup.exe');
+  fs.writeFileSync(dest, 'installer-bytes');
+  const digest = crypto.createHash('sha512').update('installer-bytes').digest('hex');
+  const previousFetch = global.fetch;
+  const respond = (text) => async () => ({ ok: true, status: 200, text: async () => text });
+  try {
+    global.fetch = respond(`${digest}  Setup.exe\n`);
+    await verifyAssetChecksum(dest, 'Setup.exe', 'https://example.test/SHA512SUMS.txt');
+
+    global.fetch = respond(`${'0'.repeat(128)}  Setup.exe\n`);
+    await assert.rejects(
+      () => verifyAssetChecksum(dest, 'Setup.exe', 'https://example.test/SHA512SUMS.txt'),
+      /sha512 不匹配/,
+    );
+
+    global.fetch = respond(`${digest}  Other.exe\n`);
+    await assert.rejects(
+      () => verifyAssetChecksum(dest, 'Setup.exe', 'https://example.test/SHA512SUMS.txt'),
+      /缺少 Setup\.exe/,
+    );
+
+    global.fetch = async () => ({ ok: false, status: 404, text: async () => '' });
+    await assert.rejects(
+      () => verifyAssetChecksum(dest, 'Setup.exe', 'https://example.test/SHA512SUMS.txt'),
+      /校验清单下载失败/,
+    );
+  } finally {
+    global.fetch = previousFetch;
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/src/main/update.test.js
+++ b/src/main/update.test.js
@@ -2,7 +2,12 @@
 
 const assert = require('node:assert/strict');
 const test = require('node:test');
-const { summarizeRelease, installRelease } = require('./update');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const https = require('node:https');
+const { EventEmitter } = require('node:events');
+const { summarizeRelease, installRelease, checkUpdate, listReleases, downloadFile } = require('./update');
 
 test('summarizeRelease skips drafts and marks a missing installer', () => {
   assert.equal(summarizeRelease({ draft: true, tag_name: 'v0.2.7' }, '0.2.6'), null);
@@ -24,6 +29,68 @@ test('summarizeRelease skips drafts and marks a missing installer', () => {
   }, '0.2.6');
   assert.equal(sourceOnly.installable, false);
   assert.equal(sourceOnly.newer, false);
+});
+
+test('checkUpdate passes an abort signal and degrades to status error on timeout', async () => {
+  const previousFetch = global.fetch;
+  let seenSignal = null;
+  global.fetch = async (_url, options) => {
+    seenSignal = options?.signal;
+    const error = new Error('The operation was aborted due to timeout');
+    error.name = 'TimeoutError';
+    throw error;
+  };
+  try {
+    const result = await checkUpdate();
+    assert.equal(result.status, 'error');
+    assert.match(result.message, /超时/);
+    assert.ok(seenSignal instanceof AbortSignal, 'fetch must receive an AbortSignal');
+  } finally {
+    global.fetch = previousFetch;
+  }
+});
+
+test('listReleases degrades to an empty list with a message on timeout', async () => {
+  const previousFetch = global.fetch;
+  global.fetch = async () => {
+    const error = new Error('aborted');
+    error.name = 'AbortError';
+    throw error;
+  };
+  try {
+    const result = await listReleases();
+    assert.equal(result.status, 'error');
+    assert.deepEqual(result.releases, []);
+    assert.match(result.message, /超时/);
+  } finally {
+    global.fetch = previousFetch;
+  }
+});
+
+test('downloadFile fails, aborts the request, and removes the partial after the overall timeout', async () => {
+  const previousGet = https.get;
+  let destroyed = false;
+  https.get = (_target, _options, _onResponse) => {
+    // Connection that never responds: only the overall deadline can settle it.
+    const request = new EventEmitter();
+    request.destroy = () => {
+      destroyed = true;
+    };
+    return request;
+  };
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-update-dl-'));
+  const dest = path.join(dir, 'setup.exe');
+  try {
+    await assert.rejects(
+      () => downloadFile('https://example.test/setup.exe', dest, null, { timeoutMs: 50 }),
+      /下载超时/,
+    );
+    assert.equal(destroyed, true);
+    assert.equal(fs.existsSync(dest), false);
+  } finally {
+    https.get = previousGet;
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('installRelease refuses a tag with no Setup.exe', async () => {

--- a/src/main/wallpaper-catalog.js
+++ b/src/main/wallpaper-catalog.js
@@ -1,5 +1,7 @@
 /** Fetch and parse wallpaper catalogs (Bing today/year, Wallhaven SFW, custom JSON). */
 
+const dns = require('node:dns');
+
 const USER_AGENT = 'Deepseek-Harness-Desktop';
 const MAX_CATALOG_BYTES = 4_000_000;
 const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
@@ -109,7 +111,11 @@ function isBlockedWallpaperHost(hostname) {
       || a === 0
       || (a === 172 && b >= 16 && b <= 31)
       || (a === 192 && b === 168)
-      || (a === 169 && b === 254);
+      || (a === 169 && b === 254)
+      // Carrier-grade NAT 100.64.0.0/10 and benchmark 198.18.0.0/15: both are
+      // non-public and reachable only inside an operator / lab network.
+      || (a === 100 && b >= 64 && b <= 127)
+      || (a === 198 && (b === 18 || b === 19));
   }
   if (host.includes(':')) {
     if (host === '::1' || host === '0:0:0:0:0:0:0:1') return !allowHttp();
@@ -186,6 +192,40 @@ function resolveAgainst(url, base) {
     return new URL(url, base).href;
   } catch {
     return '';
+  }
+}
+
+function isIpLiteralHost(host) {
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/.test(host) || host.includes(':');
+}
+
+/**
+ * Post-DNS recheck: resolve the hostname and reject when any returned
+ * address falls in a blocked range, so a public-looking name cannot point
+ * catalog IPC at loopback / RFC1918 / CGNAT targets. IP literals were
+ * already checked lexically; legitimate public image hosts resolve to
+ * public addresses and pass through unchanged. (A rebind between this
+ * lookup and the fetch connect is out of scope for this layer.)
+ * @param {string} hostname
+ * @param {string} url - for the error message.
+ * @param {(host: string, options: object) => Promise<Array<{ address: string }>>} [lookup]
+ */
+async function assertResolvedWallpaperHost(hostname, url, lookup = dns.promises.lookup) {
+  const host = String(hostname || '').replace(/^\[|\]$/g, '').toLowerCase();
+  if (!host || isIpLiteralHost(host)) {
+    return;
+  }
+  let records;
+  try {
+    records = await lookup(host, { all: true, verbatim: true });
+  } catch {
+    // Let fetch produce its own DNS failure message.
+    return;
+  }
+  for (const record of Array.isArray(records) ? records : []) {
+    if (record && typeof record.address === 'string' && isBlockedWallpaperHost(record.address)) {
+      throw new Error(catalogError(url, '解析到不允许的内网地址'));
+    }
   }
 }
 
@@ -400,7 +440,7 @@ async function readLimitedBody(response, maxBytes, url) {
  * @param {number} [hops]
  * @returns {Promise<{ buffer: Buffer, contentType: string, finalUrl: string }>}
  */
-async function fetchBuffer(url, { maxBytes, timeoutMs }, hops = 0) {
+async function fetchBuffer(url, { maxBytes, timeoutMs, lookup }, hops = 0) {
   const parsed = parseHttpUrl(url);
   if (!parsed) {
     throw new Error(catalogError(url, '地址无效'));
@@ -408,6 +448,7 @@ async function fetchBuffer(url, { maxBytes, timeoutMs }, hops = 0) {
   if (hops > MAX_REDIRECTS) {
     throw new Error(catalogError(url, '重定向过多'));
   }
+  await assertResolvedWallpaperHost(parsed.hostname, url, lookup);
   const controller = new AbortController();
   const timer = setTimeout(() => { controller.abort(); }, timeoutMs);
   try {
@@ -429,7 +470,7 @@ async function fetchBuffer(url, { maxBytes, timeoutMs }, hops = 0) {
       if (!location) {
         throw new Error(catalogError(url, '重定向无效'));
       }
-      return fetchBuffer(resolveAgainst(location, parsed.href), { maxBytes, timeoutMs }, hops + 1);
+      return fetchBuffer(resolveAgainst(location, parsed.href), { maxBytes, timeoutMs, lookup }, hops + 1);
     }
     if (!parseHttpUrl(response.url || parsed.href)) {
       throw new Error(catalogError(url, '重定向到了不允许的地址'));
@@ -593,5 +634,7 @@ module.exports = {
   listWallpaperCatalog,
   downloadWallpaper,
   isAllowedWallpaperUrl,
+  isBlockedWallpaperHost,
+  assertResolvedWallpaperHost,
   fetchFailureDetail,
 };

--- a/src/main/wallpaper-catalog.test.js
+++ b/src/main/wallpaper-catalog.test.js
@@ -2,9 +2,11 @@ const assert = require('node:assert/strict');
 const http = require('node:http');
 const test = require('node:test');
 const {
+  assertResolvedWallpaperHost,
   bingCatalogUrls,
   downloadWallpaper,
   fetchFailureDetail,
+  isBlockedWallpaperHost,
   listWallpaperCatalog,
   parseCatalogJson,
 } = require('./wallpaper-catalog');
@@ -219,6 +221,70 @@ test('listWallpaperCatalog does not fetch private or link-local HTTPS hosts', as
     assert.equal(result.items.length, 0, url);
     assert.match(result.warning, /壁纸目录/, url);
   }
+});
+
+test('isBlockedWallpaperHost blocks CGNAT and benchmark ranges but keeps neighbours public', () => {
+  delete process.env.DSHD_WALLPAPER_ALLOW_HTTP;
+  // 100.64.0.0/10 (carrier-grade NAT)
+  assert.equal(isBlockedWallpaperHost('100.64.0.0'), true);
+  assert.equal(isBlockedWallpaperHost('100.100.50.1'), true);
+  assert.equal(isBlockedWallpaperHost('100.127.255.255'), true);
+  assert.equal(isBlockedWallpaperHost('100.63.255.255'), false);
+  assert.equal(isBlockedWallpaperHost('100.128.0.0'), false);
+  // 198.18.0.0/15 (benchmarking)
+  assert.equal(isBlockedWallpaperHost('198.18.0.1'), true);
+  assert.equal(isBlockedWallpaperHost('198.19.255.254'), true);
+  assert.equal(isBlockedWallpaperHost('198.17.255.255'), false);
+  assert.equal(isBlockedWallpaperHost('198.20.0.1'), false);
+  // Existing public hosts stay allowed.
+  assert.equal(isBlockedWallpaperHost('93.184.216.34'), false);
+  assert.equal(isBlockedWallpaperHost('cn.bing.com'), false);
+});
+
+test('listWallpaperCatalog rejects HTTPS CGNAT and benchmark IP literals', async () => {
+  delete process.env.DSHD_WALLPAPER_ALLOW_HTTP;
+  for (const url of [
+    'https://100.64.1.2/secret.json',
+    'https://198.18.7.7/secret.json',
+  ]) {
+    const result = await listWallpaperCatalog({ kind: 'catalog', url });
+    assert.equal(result.items.length, 0, url);
+    assert.match(result.warning, /壁纸目录/, url);
+  }
+});
+
+test('assertResolvedWallpaperHost rejects hostnames resolving to private addresses', async () => {
+  delete process.env.DSHD_WALLPAPER_ALLOW_HTTP;
+  const privateLookup = async () => [{ address: '10.11.12.13', family: 4 }];
+  await assert.rejects(
+    () => assertResolvedWallpaperHost('evil.example.com', 'https://evil.example.com/x.json', privateLookup),
+    /解析到不允许的内网地址/,
+  );
+  const cgnatLookup = async () => [
+    { address: '93.184.216.34', family: 4 },
+    { address: '100.64.9.9', family: 4 },
+  ];
+  await assert.rejects(
+    () => assertResolvedWallpaperHost('half.example.com', 'https://half.example.com/x.json', cgnatLookup),
+    /解析到不允许的内网地址/,
+  );
+});
+
+test('assertResolvedWallpaperHost keeps public results and tolerates DNS failure', async () => {
+  delete process.env.DSHD_WALLPAPER_ALLOW_HTTP;
+  const publicLookup = async () => [
+    { address: '93.184.216.34', family: 4 },
+    { address: '2606:2800:220:1:248:1893:25c8:1946', family: 6 },
+  ];
+  await assertResolvedWallpaperHost('example.com', 'https://example.com/x.json', publicLookup);
+  const failingLookup = async () => { throw new Error('getaddrinfo ENOTFOUND'); };
+  await assertResolvedWallpaperHost('gone.example.com', 'https://gone.example.com/x.json', failingLookup);
+  // IP literals were checked lexically; the resolver must not be consulted.
+  let called = 0;
+  const countingLookup = async () => { called += 1; return []; };
+  await assertResolvedWallpaperHost('93.184.216.34', 'https://93.184.216.34/x.json', countingLookup);
+  await assertResolvedWallpaperHost('[2606:2800::1]', 'https://[2606:2800::1]/x.json', countingLookup);
+  assert.equal(called, 0);
 });
 
 test('listWallpaperCatalog accepts a catalog under 4MB and drops one above it', async () => {

--- a/src/main/workspace-authority.js
+++ b/src/main/workspace-authority.js
@@ -1,6 +1,7 @@
 const fs = require('node:fs');
+const os = require('node:os');
 const path = require('node:path');
-const { getDesktopDshHome } = require('../shared/dsh-home');
+const { getDesktopDshHome, tryGetDesktopDshHome } = require('../shared/dsh-home');
 
 /**
  * Workspace authority: the trust roots for desktop capabilities that touch
@@ -234,18 +235,68 @@ function isFilesystemRoot(dir) {
 }
 
 /**
+ * Sensitive anchors that a plugin-writable trust root must never equal or
+ * contain: the user home (SSH keys, credentials), the per-user config trees
+ * (`%APPDATA%`, `Application Support`, `~/.config`), and the desktop
+ * userData/dsh-home (this app's own config, tokens, sessions).
+ * @returns {string[]} canonical anchor paths that exist on this machine.
+ */
+function highRiskAnchorPaths() {
+  const candidates = [];
+  const home = os.homedir();
+  if (home) {
+    candidates.push(home);
+    if (process.platform === 'darwin') {
+      candidates.push(path.join(home, 'Library'), path.join(home, 'Library', 'Application Support'));
+    }
+    candidates.push(path.join(home, '.config'), path.join(home, '.ssh'));
+  }
+  for (const key of ['APPDATA', 'LOCALAPPDATA', 'XDG_CONFIG_HOME', 'XDG_DATA_HOME']) {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim() !== '') candidates.push(value);
+  }
+  const desktopHome = tryGetDesktopDshHome();
+  if (desktopHome) {
+    candidates.push(desktopHome, path.dirname(desktopHome));
+  }
+  const anchors = [];
+  for (const candidate of candidates) {
+    const real = realPathOrNull(path.resolve(candidate));
+    if (real !== null) anchors.push(real);
+  }
+  return anchors;
+}
+
+/**
+ * True when trusting `real` as a workspace root would expose a high-risk
+ * anchor: the root equals an anchor or is one of its ancestors (the anchor
+ * lives inside the root). Ordinary project folders — including siblings of
+ * the boot workspace under Documents or any dev directory — contain none of
+ * the anchors and stay accepted.
+ * @param {string} real - canonical registered root.
+ * @param {string[]} [anchors] - injectable for tests.
+ * @returns {boolean}
+ */
+function isHighRiskWorkspaceRoot(real, anchors = highRiskAnchorPaths()) {
+  return anchors.some((anchor) => containedIn(real, anchor));
+}
+
+/**
  * Harness `workspace.json` is plugin-writable. Keep user-opened project
- * folders (including siblings of the boot workspace) and drop volume roots.
+ * folders (including siblings of the boot workspace); drop volume roots and
+ * high-risk ancestors (user home, `%APPDATA%` / Application Support,
+ * userData / desktop dsh-home).
  * @param {unknown[]} listed
  * @returns {string[]}
  */
 function filterRegisteredWorkspaceRoots(listed) {
   const rows = Array.isArray(listed) ? listed : [];
+  const anchors = highRiskAnchorPaths();
   return rows.filter((raw) => {
     if (typeof raw !== 'string' || raw.trim() === '') return false;
     try {
       const real = fs.realpathSync(path.resolve(raw));
-      return !isFilesystemRoot(real);
+      return !isFilesystemRoot(real) && !isHighRiskWorkspaceRoot(real, anchors);
     } catch {
       return false;
     }
@@ -280,5 +331,8 @@ module.exports = {
   createWorkspaceAuthority,
   loadWorkspaceAuthority,
   readHarnessRegisteredWorkspacePaths,
+  filterRegisteredWorkspaceRoots,
+  isHighRiskWorkspaceRoot,
+  highRiskAnchorPaths,
   scratchWorkspacePath,
 };

--- a/src/main/workspace-authority.test.js
+++ b/src/main/workspace-authority.test.js
@@ -7,6 +7,9 @@ const {
   createWorkspaceAuthority,
   loadWorkspaceAuthority,
   readHarnessRegisteredWorkspacePaths,
+  filterRegisteredWorkspaceRoots,
+  isHighRiskWorkspaceRoot,
+  highRiskAnchorPaths,
   scratchWorkspacePath,
 } = require('./workspace-authority');
 const { setDesktopDshHome, clearDesktopDshHome } = require('../shared/dsh-home');
@@ -328,6 +331,90 @@ test('loadWorkspaceAuthority authorizes a harness-registered workspace outside t
     else delete require.cache[require.resolve('./config')];
     clearDesktopDshHome();
     fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(boot, { recursive: true, force: true });
+    fs.rmSync(sibling, { recursive: true, force: true });
+  }
+});
+
+test('isHighRiskWorkspaceRoot rejects anchors and their ancestors, keeps ordinary projects', () => {
+  const base = makeRoot();
+  try {
+    const anchorParent = path.join(base, 'users', 'me');
+    const anchor = path.join(anchorParent, 'AppData');
+    const project = path.join(anchorParent, 'Documents', 'proj');
+    fs.mkdirSync(anchor, { recursive: true });
+    fs.mkdirSync(project, { recursive: true });
+    const anchors = [fs.realpathSync(anchor)];
+    assert.equal(isHighRiskWorkspaceRoot(fs.realpathSync(anchor), anchors), true);
+    assert.equal(isHighRiskWorkspaceRoot(fs.realpathSync(anchorParent), anchors), true);
+    assert.equal(isHighRiskWorkspaceRoot(fs.realpathSync(project), anchors), false);
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('filterRegisteredWorkspaceRoots drops the user home and the desktop dsh-home root', () => {
+  const home = makeRoot();
+  const userData = path.join(home, 'userData');
+  const dshHome = path.join(userData, 'dsh-home');
+  const sibling = makeRoot();
+  fs.mkdirSync(dshHome, { recursive: true });
+  try {
+    setDesktopDshHome(dshHome);
+    const kept = filterRegisteredWorkspaceRoots([
+      os.homedir(),
+      dshHome,
+      userData,
+      sibling,
+      '',
+      42,
+    ]);
+    assert.deepEqual(kept, [sibling]);
+    assert.ok(highRiskAnchorPaths().includes(fs.realpathSync(os.homedir())));
+  } finally {
+    clearDesktopDshHome();
+    fs.rmSync(home, { recursive: true, force: true });
+    fs.rmSync(sibling, { recursive: true, force: true });
+  }
+});
+
+test('loadWorkspaceAuthority ignores a registered user-home or dsh-home trust root', () => {
+  const base = makeRoot();
+  const home = path.join(base, 'dsh-home');
+  const boot = makeRoot();
+  const sibling = makeRoot();
+  fs.mkdirSync(home, { recursive: true });
+  const previousConfig = require.cache[require.resolve('./config')];
+  try {
+    fs.mkdirSync(path.join(home, 'storages'));
+    fs.writeFileSync(path.join(home, 'storages', 'workspace.json'), `${JSON.stringify({
+      unit: { name: 'workspace', version: 2 },
+      tables: {
+        workspaces: {
+          'ws-home': { path: os.homedir() },
+          'ws-dsh-home': { path: home },
+          'ws-user-data': { path: base },
+          'ws-sibling': { path: sibling },
+        },
+      },
+    })}\n`, 'utf8');
+    require.cache[require.resolve('./config')] = {
+      id: require.resolve('./config'),
+      filename: require.resolve('./config'),
+      loaded: true,
+      exports: { loadConfig: () => ({ workspace: boot }) },
+    };
+    setDesktopDshHome(home);
+    const authority = loadWorkspaceAuthority();
+    assert.equal(authority.resolveAuthorizedCwd(os.homedir()), null);
+    assert.equal(authority.resolveAuthorizedCwd(home), null);
+    assert.equal(authority.resolveAuthorizedCwd(base), null);
+    assert.equal(authority.resolveAuthorizedCwd(sibling), canonical(sibling));
+  } finally {
+    if (previousConfig) require.cache[require.resolve('./config')] = previousConfig;
+    else delete require.cache[require.resolve('./config')];
+    clearDesktopDshHome();
+    fs.rmSync(base, { recursive: true, force: true });
     fs.rmSync(boot, { recursive: true, force: true });
     fs.rmSync(sibling, { recursive: true, force: true });
   }

--- a/src/renderer/launcher.js
+++ b/src/renderer/launcher.js
@@ -184,6 +184,9 @@ function pluginSkipLabel(reason) {
   if (reason === 'local-spec') {
     return '本地 file / link / workspace，不重装';
   }
+  if (reason === 'unsupported') {
+    return '规格不受支持，无法自动重装';
+  }
   return reason || '跳过';
 }
 
@@ -560,6 +563,10 @@ function bind() {
   }
   if (api?.onLauncherHint) {
     api.onLauncherHint((payload) => {
+      if (payload?.importResume) {
+        setHint('上次导入中途中断，已清理未完成的临时文件。可以直接重新导入：已导入的目录会自动跳过。');
+        return;
+      }
       const check = payload?.check;
       if (check?.status === 'error') {
         setHint(`更新检查失败：${check.message || '网络或 GitHub 不可用'}。仍可启动桌面端。`);

--- a/src/shared/dsh-home.js
+++ b/src/shared/dsh-home.js
@@ -45,6 +45,24 @@ function tryGetDesktopDshHome() {
   }
 }
 
+/**
+ * In packaged builds an inherited `DSHD_HOME` must not silently redirect the
+ * desktop home away from `userData/dsh-home`; it is honored only with the
+ * explicit `DSHD_ALLOW_ENV_HOME=1` switch. Dev / debug (non-packaged) runs
+ * keep the override as-is. Call once at main-process startup, before the
+ * home is first resolved.
+ * @param {{ isPackaged?: boolean, env?: NodeJS.ProcessEnv }} [options]
+ * @returns {{ dropped: boolean, value: string }}
+ */
+function sanitizePackagedDshHomeEnv({ isPackaged = false, env = process.env } = {}) {
+  const value = typeof env.DSHD_HOME === 'string' ? env.DSHD_HOME : '';
+  if (!isPackaged || !value.trim() || env.DSHD_ALLOW_ENV_HOME === '1') {
+    return { dropped: false, value };
+  }
+  delete env.DSHD_HOME;
+  return { dropped: true, value };
+}
+
 function applyDesktopDshHome(env = {}) {
   const next = { ...env };
   for (const key of Object.keys(next)) {
@@ -62,4 +80,5 @@ module.exports = {
   getDesktopDshHome,
   tryGetDesktopDshHome,
   applyDesktopDshHome,
+  sanitizePackagedDshHomeEnv,
 };

--- a/src/shared/dsh-home.test.js
+++ b/src/shared/dsh-home.test.js
@@ -13,6 +13,7 @@ const {
   getDesktopDshHome,
   tryGetDesktopDshHome,
   applyDesktopDshHome,
+  sanitizePackagedDshHomeEnv,
 } = require('./dsh-home');
 
 function withEnv(key, value, work) {
@@ -74,6 +75,29 @@ test('applyDesktopDshHome overwrites an inherited DSH_HOME', () => {
   });
   assert.equal(env.DSH_HOME, path.resolve(configured));
   assert.equal(env.KEEP, 'yes');
+});
+
+test('sanitizePackagedDshHomeEnv drops DSHD_HOME in packaged builds without the switch', () => {
+  const inherited = path.join(os.tmpdir(), 'stray-dshd-home');
+  const env = { DSHD_HOME: inherited };
+  const result = sanitizePackagedDshHomeEnv({ isPackaged: true, env });
+  assert.equal(result.dropped, true);
+  assert.equal(result.value, inherited);
+  assert.equal('DSHD_HOME' in env, false);
+});
+
+test('sanitizePackagedDshHomeEnv keeps DSHD_HOME with DSHD_ALLOW_ENV_HOME=1 or in dev', () => {
+  const inherited = path.join(os.tmpdir(), 'wanted-dshd-home');
+  const packagedAllowed = { DSHD_HOME: inherited, DSHD_ALLOW_ENV_HOME: '1' };
+  assert.equal(sanitizePackagedDshHomeEnv({ isPackaged: true, env: packagedAllowed }).dropped, false);
+  assert.equal(packagedAllowed.DSHD_HOME, inherited);
+
+  const dev = { DSHD_HOME: inherited };
+  assert.equal(sanitizePackagedDshHomeEnv({ isPackaged: false, env: dev }).dropped, false);
+  assert.equal(dev.DSHD_HOME, inherited);
+
+  const unset = {};
+  assert.equal(sanitizePackagedDshHomeEnv({ isPackaged: true, env: unset }).dropped, false);
 });
 
 test('applyDesktopDshHome drops case variants then sets DSH_HOME', () => {

--- a/src/shared/harness-sync.test.js
+++ b/src/shared/harness-sync.test.js
@@ -10,6 +10,11 @@ const { spawnSync } = require('node:child_process');
 const { readPin, writePin } = require('./harness-upstream');
 const { parseSyncArgs, syncHarness, BACKUP_REF, STATE_RELATIVE } = require('./harness-sync');
 
+// Keep git fixtures hermetic: no global insteadOf rewrites or system config.
+process.env.GIT_CONFIG_GLOBAL = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-git-isolation-')), 'gitconfig');
+fs.writeFileSync(process.env.GIT_CONFIG_GLOBAL, '');
+process.env.GIT_CONFIG_NOSYSTEM = '1';
+
 function git(cwd, args, options = {}) {
   return spawnSync('git', args, { cwd, encoding: 'utf8', shell: false, ...options });
 }

--- a/src/shared/harness-upstream.test.js
+++ b/src/shared/harness-upstream.test.js
@@ -26,6 +26,11 @@ const RC5_PIN = {
   npm: '0.1.0-rc.5',
 };
 
+// Keep git fixtures hermetic: no global insteadOf rewrites or system config.
+process.env.GIT_CONFIG_GLOBAL = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-git-isolation-')), 'gitconfig');
+fs.writeFileSync(process.env.GIT_CONFIG_GLOBAL, '');
+process.env.GIT_CONFIG_NOSYSTEM = '1';
+
 function git(args, options) {
   return spawnSync('git', args, { encoding: 'utf8', shell: false, ...options });
 }

--- a/src/shared/official-deepseek-env.js
+++ b/src/shared/official-deepseek-env.js
@@ -8,7 +8,8 @@ const OFFICIAL_DEEPSEEK_HOST = 'api.deepseek.com';
 
 /**
  * True when the shell gateway is official DeepSeek: empty/whitespace (public
- * API default) or a URL whose hostname is api.deepseek.com.
+ * API default) or an https URL whose hostname is api.deepseek.com. Plain
+ * http is rejected so credentials are never aliased onto a cleartext origin.
  * @param {unknown} baseUrl
  * @returns {boolean}
  */
@@ -21,7 +22,7 @@ function isOfficialDeepSeekBaseUrl(baseUrl) {
   } catch {
     return false;
   }
-  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return false;
+  if (parsed.protocol !== 'https:') return false;
   return parsed.hostname.toLowerCase() === OFFICIAL_DEEPSEEK_HOST;
 }
 

--- a/src/shared/official-deepseek-env.test.js
+++ b/src/shared/official-deepseek-env.test.js
@@ -13,19 +13,28 @@ test('empty or whitespace baseUrl is official DeepSeek (public API default)', ()
   assert.equal(isOfficialDeepSeekBaseUrl('   '), true);
 });
 
-test('api.deepseek.com http(s) URLs are official', () => {
+test('api.deepseek.com https URLs are official', () => {
   assert.equal(isOfficialDeepSeekBaseUrl('https://api.deepseek.com'), true);
   assert.equal(isOfficialDeepSeekBaseUrl('https://api.deepseek.com/'), true);
   assert.equal(isOfficialDeepSeekBaseUrl('https://api.deepseek.com/v1'), true);
   assert.equal(isOfficialDeepSeekBaseUrl('https://API.DEEPSEEK.COM/v1'), true);
-  assert.equal(isOfficialDeepSeekBaseUrl('http://api.deepseek.com'), true);
 });
 
-test('third-party and invalid URLs are not official DeepSeek', () => {
+test('third-party, cleartext, and invalid URLs are not official DeepSeek', () => {
   assert.equal(isOfficialDeepSeekBaseUrl('https://ayase.cn/v1'), false);
   assert.equal(isOfficialDeepSeekBaseUrl('https://api.deepseek.com.evil.example/v1'), false);
   assert.equal(isOfficialDeepSeekBaseUrl('not a url'), false);
   assert.equal(isOfficialDeepSeekBaseUrl('ftp://api.deepseek.com'), false);
+  assert.equal(isOfficialDeepSeekBaseUrl('http://api.deepseek.com'), false);
+});
+
+test('applyOfficialDeepSeekSpawnEnv never aliases onto a cleartext official host', () => {
+  const env = applyOfficialDeepSeekSpawnEnv({}, {
+    apiKey: 'sk-official',
+    baseUrl: 'http://api.deepseek.com',
+  });
+  assert.equal(env.DEEPSEEK_API_KEY, undefined);
+  assert.equal(env.DEEPSEEK_BASE_URL, undefined);
 });
 
 test('applyOfficialDeepSeekSpawnEnv does not write Ayase onto DEEPSEEK_*', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

落实 v0.2.6→HEAD 审查项的修复与加固，不丢失现有功能。

## 变更

- **H1 data-import**：扫描预标 `unsupported`；受控 `name@semver` registry 重装；渲染通道保持 github-only
- **M1 harness-extract**：archive 缺失时不再删除可用 runtime，降级复用并告警
- **M2 update**：检查 10s / 下载 15min 超时；失败不阻塞手动启动
- **M3 journal**：冷启动消费 `phase:'copying'`，清理 `.import-tmp` 并提示可安全重跑
- **M4 workspace**：拒绝高危祖先作信任根；兄弟项目场景保留
- **M5 QA**：惰性 require；packaged 下需 `DSHD_ALLOW_PACKAGED_QA=1`
- **M6 release**：发布前校验同 SHA `test.yml` 已绿；macOS best-effort 文档化
- **L1/L3/L5/L6/L7** 与 **N1/N2**：SSRF 加固、https-only 官方 baseUrl、`SHA512SUMS.txt`、packaged `DSHD_HOME` 门控、git 测试隔离、死代码注释/清理

## 验证

`npm test`：823 pass / 0 fail / 3 skip（平台性）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99361115-e1cc-4a23-a154-a522a5c64229?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99361115-e1cc-4a23-a154-a522a5c64229&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

