### PR TITLE
harden: sanitize child_process call in setup-harness.js...

### DIFF
--- a/scripts/setup-harness.js
+++ b/scripts/setup-harness.js
@@ -15,12 +15,26 @@ function harnessEnv() {
   };
 }
 
-function run(command, args, cwd) {
-  console.log(`> ${command} ${args.join(' ')}`);
-  const result = spawnSync(command, args, {
+function runGit(args, cwd) {
+  console.log(`> git ${args.join(' ')}`);
+  const result = spawnSync('git', args, {
     cwd,
     stdio: 'inherit',
     env: harnessEnv(),
+    shell: false,
+  });
+  if (result.status !== 0) {
+    process.exit(result.status || 1);
+  }
+}
+
+function runNode(args, cwd) {
+  console.log(`> node ${args.join(' ')}`);
+  const result = spawnSync(process.execPath, args, {
+    cwd,
+    stdio: 'inherit',
+    env: harnessEnv(),
+    shell: false,
   });
   if (result.status !== 0) {
     process.exit(result.status || 1);
@@ -30,7 +44,7 @@ function run(command, args, cwd) {
 if (!fs.existsSync(path.join(vendor, 'package.json'))) {
   const pin = readPin(root);
   fs.mkdirSync(path.dirname(vendor), { recursive: true });
-  run('git', ['clone', '--depth', '1', '--branch', pin.ref, pin.repo, vendor], root);
+  runGit(['clone', '--depth', '1', '--branch', pin.ref, pin.repo, vendor], root);
   const head = spawnSync('git', ['rev-parse', 'HEAD'], {
     cwd: vendor,
     encoding: 'utf8',
@@ -42,8 +56,8 @@ if (!fs.existsSync(path.join(vendor, 'package.json'))) {
   }
 }
 
-run(process.execPath, [pnpm, 'install', '--frozen-lockfile'], vendor);
-run(process.execPath, [pnpm, 'run', 'build'], vendor);
+runNode([pnpm, 'install', '--frozen-lockfile'], vendor);
+runNode([pnpm, 'run', 'build'], vendor);
 
 // Root build:lib:client copies Ghostty wasm/font; still ensure lib/assets beside client.js.
 const { ensureGhosttyAssetsInHarness, harnessHasGhosttyAssets, missingGhosttyAssetPaths } = require(


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/setup-harness.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/setup-harness.js:20` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `command`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `scripts/setup-harness.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
