### PR TITLE
feature(surfaces-work-loops): shorten empty-state card height

### DIFF
--- a/docs/features/surfaces-work-loops.md
+++ b/docs/features/surfaces-work-loops.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `surfaces-work-loops` |
 | **status** | `active` |
-| **last verified** | 2026-08-25 — `workspace-fs.writeFile` 增加 `.git` 段拦截（安全审查 L-4），`workspace-fs.test.js` 9/9 绿。此前同日（合并树 `ea659884`，consolidation #39 落地后）— desktop `npm test` 997/0/3 绿；harness `test:gui` 409 文件 5338 绿（`node-half.client.spec.ts` 源面解析修复后 0 红）；`qa:source` surfaces/terminal/files/diff/agents 步骤全 PASS（同日第二轮：壁纸三步归因为 walk 英文匹配缺口并修复后，qa:source 整表全绿 exit 0）。此前同日：硬化计划 PR-A~D（保存竞态串行化、preview-automation 全链删除、preview-workspace 流式+上限、每搜索会话一次 walk + 批量 check-ignore、persist 死字段清除、gitInit 后 Diff 门重探、草稿上限按字节） |
+| **last verified** | 2026-08-26 — 空态卡片压扁为紧凑矩形（图标与标题同行、描述占满下行，`min-height` 112→64px，padding 16→10/12px；仅 `EmptyState.module.css`，令牌不变），ui-surfaces 11 文件 88 测试全绿。此前 2026-08-25 — `workspace-fs.writeFile` 增加 `.git` 段拦截（安全审查 L-4），`workspace-fs.test.js` 9/9 绿。此前同日（合并树 `ea659884`，consolidation #39 落地后）— desktop `npm test` 997/0/3 绿；harness `test:gui` 409 文件 5338 绿（`node-half.client.spec.ts` 源面解析修复后 0 红）；`qa:source` surfaces/terminal/files/diff/agents 步骤全 PASS（同日第二轮：壁纸三步归因为 walk 英文匹配缺口并修复后，qa:source 整表全绿 exit 0）。此前同日：硬化计划 PR-A~D（保存竞态串行化、preview-automation 全链删除、preview-workspace 流式+上限、每搜索会话一次 walk + 批量 check-ignore、persist 死字段清除、gitInit 后 Diff 门重探、草稿上限按字节） |
 
 ## User paths
 

--- a/vendor/deepseek-harness/packages/client/ui-surfaces/src/client/EmptyState.module.css
+++ b/vendor/deepseek-harness/packages/client/ui-surfaces/src/client/EmptyState.module.css
@@ -39,11 +39,13 @@
 }
 
 .card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  min-height: 112px;
-  padding: 16px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 8px;
+  align-items: center;
+  align-content: center;
+  min-height: 64px;
+  padding: 10px 12px;
   border: none;
   border-radius: 12px;
   background: var(--dsw-alias-bg-layer-2);
@@ -54,7 +56,7 @@
 
 .cardWrap {
   display: flex;
-  min-height: 112px;
+  min-height: 64px;
 }
 
 .cardWrap .card {
@@ -77,7 +79,6 @@
 }
 
 .icon {
-  margin-bottom: 12px;
   color: var(--dsw-alias-label-secondary);
 }
 
@@ -88,7 +89,8 @@
 }
 
 .cardDescription {
-  margin-top: 4px;
+  grid-column: 1 / -1;
+  margin-top: 2px;
   font-size: 12px;
   line-height: 18px;
   color: var(--dsw-alias-label-tertiary);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Right-sidebar EmptyState surface cards were tall vertical rectangles. This PR tightens them into shorter, more balanced compact cards while staying on official `--dsw-alias-*` tokens.

## Changes
- `EmptyState.module.css`: switch cards from stacked flex column to a compact 2-col grid (icon + title on one row, description full-width below); lower `min-height` 112 → 64px; tighten padding.
- Update `docs/features/surfaces-work-loops.md` `last verified`.

## Test plan
- [x] ui-surfaces client specs (88) green on cloud agent
- [ ] Manual: `Ctrl+\` empty state — five cards look shorter in light/dark and narrow/wide column
- [ ] Manual: disabled Browser/Diff tooltips still work
- [ ] Optional: screenshot before/after for visual review

Touching: `surfaces-work-loops`
Cloud agent model: `claude-fable-5-thinking-high`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11c17940-e43f-4db2-b2f6-553557b762c2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11c17940-e43f-4db2-b2f6-553557b762c2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

