### PR TITLE
feature(decoupling): Phase 0 — fork-delta ratchet, sync dry-run sentinel, token-mirror gate

### DIFF
--- a/.github/workflows/harness-sync-dry-run.yml
+++ b/.github/workflows/harness-sync-dry-run.yml
@@ -1,0 +1,37 @@
+# 解耦 Phase 0 定时哨兵：每周对上游 HEAD 重放 sync:harness 的 --dry-run，
+# 持续给下一次 pin bump 报价（冲突数与冲突文件清单）。只读——不改 pin、
+# 不留 worktree；冲突本身不判失败，只有基础设施错误（fetch、脏树）才红。
+name: Harness sync dry-run
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # 每周一 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Upstream ref to price (default: upstream HEAD)'
+        required: false
+        default: 'HEAD'
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Replay subtree merge against upstream (report only)
+        # 干跑内部的 synthetic-ours commit-tree 需要 git 身份；runner 默认没有。
+        env:
+          GIT_AUTHOR_NAME: harness-sync-dry-run
+          GIT_AUTHOR_EMAIL: ci@localhost
+          GIT_COMMITTER_NAME: harness-sync-dry-run
+          GIT_COMMITTER_EMAIL: ci@localhost
+        run: node scripts/check-harness-sync-dry-run.js --ref "${{ github.event.inputs.ref || 'HEAD' }}" --json sync-dry-run.json
+      - name: Upload conflict report
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-sync-dry-run
+          path: sync-dry-run.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,21 @@ jobs:
       - name: Run desktop unit tests
         run: npm test
 
+  # 解耦 Phase 0 望远镜：vendored 树 vs 上游 pin 的 fork 面必须被
+  # harness-desktop-forks.js 登记；未登记漂移超过基线即失败（棘轮）。
+  # 只读、零依赖（node + git），pin 对象缺失时从上游 fetch。
+  fork-delta:
+    name: Harness fork delta vs upstream pin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Classify fork delta against the registry baseline
+        run: node scripts/check-harness-fork-delta.js
+
   vendor-gui:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -23,6 +23,10 @@
 - **更新：** 不变量或关键路径变了；或改完后刷新 `last verified`。
 - **局部修复不改契约：** 会话写明「无卡 / 不改产品契约」，diff 仍应尽量小。
 
+## 新桌面能力的默认形态（sidecar-by-default）
+
+新桌面能力**默认做成 vendor 树外的 sidecar 插件**（Cordis 插件 + 桌面 overlay 挂载；样板：dsh-usage-panel / dsh-im / dshbot），除非它必须修改上游代码。必须改上游时，把 fork 面登记进 [src/shared/harness-desktop-forks.js](../../src/shared/harness-desktop-forks.js)（整包 → `DESKTOP_PACKAGES`；上游文件内改动 → `FORK_FILE_MARKERS`；bundle 组合行 → `COMPOSITION_ROWS`），否则 CI 的 fork-delta 棘轮（`npm run check:fork-delta`）会超基线变红。依据：[解耦分析 §2.F](../superpowers/plans/2026-08-27-dsh-decoupling-analysis.md)。
+
 ## 会话开场模板
 
 ```text

--- a/docs/superpowers/plans/2026-08-27-dsh-decoupling-phase0-execution.md
+++ b/docs/superpowers/plans/2026-08-27-dsh-decoupling-phase0-execution.md
@@ -29,7 +29,7 @@ Diff `git diff-tree -r 528c682e^{tree} HEAD:vendor/deepseek-harness`, 1,372 chan
 
 The 604 unregistered-modified count is the §6.1 gap made machine-readable (analysis estimated ~605: 625 modified minus markers). Unregistered-added hotspots are dominated by `.agents/notes` (232) and desktop feature slices in `apps/web` / `ui-conversation` / `ui-theme`. Baseline constants live in `src/shared/harness-fork-delta.js` (`UNREGISTERED_BASELINE = { total: 921, modified: 604 }`); the CI gate fails only when a count **exceeds** its baseline, and prints a reminder to lower the baseline when drift shrinks.
 
-Sync dry-run vs upstream `dsh-v0.1.1-rc.2` (`b150a551`, current upstream HEAD): **20 conflict files** (runtime sessions contract, ui-conversation locales/skeleton, ui-permission-presets, apiproxy sessions API, llm/tool-fs docs + read-image snapshot, ui-layout package.json).
+Sync dry-run vs upstream `dsh-v0.1.1-rc.2` (`b150a551`, latest tag): **20 conflict files** (runtime sessions contract, ui-conversation locales/skeleton, ui-permission-presets, apiproxy sessions API, llm/tool-fs docs + read-image snapshot, ui-layout package.json). Upstream `HEAD` moved past rc.2 **during this session** (to `cd5ef814`) and the same dry-run against it reports **311 conflicts** — post-rc.2 development is fast; this live jump is the case for the weekly sentinel.
 
 ## Gates
 

--- a/docs/superpowers/plans/2026-08-27-dsh-decoupling-phase0-execution.md
+++ b/docs/superpowers/plans/2026-08-27-dsh-decoupling-phase0-execution.md
@@ -1,0 +1,44 @@
+# dsh decoupling Phase 0 execution — instrument the boundary
+
+**Date:** 2026-08-27 · **Baseline:** `main@581547eb` · **Branch:** `cursor/dsh-decoupling-phase0-aebd`
+**Parent analysis:** [2026-08-27-dsh-decoupling-analysis.md](2026-08-27-dsh-decoupling-analysis.md) (§4 migration path)
+
+**Touching:** no feature card — tooling + docs only. No product behavior, IPC, overlay, spawn, or composition change. Wholesale decoupling (Scenarios B/D/E) stays rejected per the analysis; this executes Phase 0 plus the safe Phase 1/2 documentation slices.
+
+## Scope
+
+| Item | Analysis ref | Deliverable |
+| --- | --- | --- |
+| 0.1 Fork-delta classifier | §4 Phase 0, §6.1 | `src/shared/harness-fork-delta.js` (+ tests) classifying diff-vs-pin paths into registered-package / marked-file / composition / unregistered; runner `scripts/check-harness-fork-delta.js`; `npm run check:fork-delta`; CI job in `test.yml` (PR-blocking against a measured baseline) |
+| 0.2 Upstream sync dry-run | §4 Phase 0, §2.C.2 | `scripts/check-harness-sync-dry-run.js` reusing `harness-sync.js --dry-run`; `npm run check:sync-dry-run`; scheduled + manual workflow `.github/workflows/harness-sync-dry-run.yml` (report-only, no pin bump) |
+| 0.3 Token mirror drift check | §6.5, §1.6 | `src/shared/dsh-webui-token-mirror.js` (+ tests incl. an integration case on the real files) comparing `src/shared/dsh-webui-tokens.css` `--dsw-*` values against resolved `ui-theme design-platform.css`; runs inside `npm test` |
+| 1.1 dsh-tools handoff refresh | §2.G | Verify the post-merge cherry-pick instructions in [2026-08-27-dsh-tools-upstream-handoff.md](2026-08-27-dsh-tools-upstream-handoff.md) actually apply; record that upstream moved to `dsh-v0.1.1-rc.2` without the fix. No pin change |
+| 2.1 Sidecar-by-default policy | §2.F rule | Short policy section in `docs/features/README.md` |
+| 2.2 Host-package extraction | §2.F | **Documented only, not executed** — candidates `packages/host/mcp-servers`, `host/skill-inventory`, `mcp/mcp-servers-file`, `llm/llm-vision-fallback`; deferred until one of them next needs real changes (analysis: “opportunistically, not as a program”) |
+
+## Measured numbers (2026-08-27, pin `dsh-v0.1.1-rc.1` @ `528c682e`)
+
+Diff `git diff-tree -r 528c682e^{tree} HEAD:vendor/deepseek-harness`, 1,372 changed paths:
+
+| Bucket | Count |
+| --- | --- |
+| registered-package (under a `DESKTOP_PACKAGES` dir) | 431 |
+| marked-file (`FORK_FILE_MARKERS`) | 18 |
+| composition (`COMPOSITION_ROWS` patch files) | 2 |
+| **unregistered** | **921** (306 added, **604 modified upstream files**, 8 type changes, 3 deleted) |
+
+The 604 unregistered-modified count is the §6.1 gap made machine-readable (analysis estimated ~605: 625 modified minus markers). Unregistered-added hotspots are dominated by `.agents/notes` (232) and desktop feature slices in `apps/web` / `ui-conversation` / `ui-theme`. Baseline constants live in `src/shared/harness-fork-delta.js` (`UNREGISTERED_BASELINE = { total: 921, modified: 604 }`); the CI gate fails only when a count **exceeds** its baseline, and prints a reminder to lower the baseline when drift shrinks.
+
+Sync dry-run vs upstream `dsh-v0.1.1-rc.2` (`b150a551`, current upstream HEAD): **20 conflict files** (runtime sessions contract, ui-conversation locales/skeleton, ui-permission-presets, apiproxy sessions API, llm/tool-fs docs + read-image snapshot, ui-layout package.json).
+
+## Gates
+
+- `npm test` (includes the new classifier + token-mirror suites; token integration case reads the real CSS pair)
+- `node scripts/check-harness-fork-delta.js` green at baseline
+- `node scripts/check-harness-sync-dry-run.js` completes read-only and reports the conflict count
+- No change to `check-skip-compose-contract.js` inputs → not re-run beyond CI
+- vendor `test:gui` untouched (no vendor-tree file changes in this branch)
+
+## Rollback
+
+Delete the two scripts, the two CI additions, and the two shared modules; revert the doc edits. No runtime surface depends on any of it.

--- a/docs/superpowers/plans/2026-08-27-dsh-tools-upstream-handoff.md
+++ b/docs/superpowers/plans/2026-08-27-dsh-tools-upstream-handoff.md
@@ -4,9 +4,11 @@
 
 **Do not** update `vendor/harness-upstream.json` until upstream has merged and tagged a release containing the fix; the pin records the integrated official baseline, never a pending PR.
 
+**Upstream status check (2026-08-27):** upstream has since tagged `dsh-v0.1.1-rc.2` (`b150a551`, current upstream HEAD). Verified it does **not** contain the fix (`requireValidToolCallIdentity` absent from `b150a551:packages/llm/llm/src/content.ts`), so this handoff is still pending; base the upstream branch on rc.2.
+
 ## What the patch contains
 
-All changes live under `vendor/deepseek-harness/` and are now **merged into `main`** via PR #54 (merge commit `cac4f790`; the fix itself is `f8c1deb7`, and the original head branch `cursor/fix-unknown-tool-empty-name-8eab` has been deleted). They apply cleanly to the upstream tree because the touched packages carry no desktop-fork edits:
+All changes live under `vendor/deepseek-harness/` and are now **merged into `main`** via PR #54 (merge commit `cac4f790`; the fix itself is `f8c1deb7`, and the original head branch `cursor/fix-unknown-tool-empty-name-8eab` has been deleted). Two touched packages (`core/session`, `core/agent-loop`) also carry the earlier desktop commit `ddabf839` (tool-call result pairing recovery for scheduler failures — same tool-call-integrity area, `tool-transcript.ts` predates #54), so the upstream submission is the **cumulative** touched-path diff vs. the pin, covering both fixes:
 
 - `packages/llm/llm/` — `requireValidToolCallIdentity` / `isValidToolCallIdentity` (`content.ts`), assembler rejection of nameless or id-less tool calls, `MALFORMED_RESPONSE` failure code added to the default retryable set (`retry-policy.ts`, `error.ts`), optional `id`/`name` on `tool-call-delta` (`types.ts`).
 - `packages/llm/llm-deepseek/` + `packages/llm/llm-pi-ai/` — adapters stop defaulting absent tool-call ids/names to empty strings.
@@ -21,7 +23,19 @@ All changes live under `vendor/deepseek-harness/` and are now **merged into `mai
 
 ## Submission checklist
 
-- [ ] Extract the `vendor/deepseek-harness/` diff onto a fresh branch of `deepseek-ai/deepseek-harness` (the source branch is deleted; diff the merge commit instead, e.g. `git diff cac4f790^1...cac4f790 -- vendor/deepseek-harness/ | git apply -p3 --directory=.` from the upstream checkout, or cherry-pick `f8c1deb7` with path rewrite).
+- [ ] Extract the cumulative diff onto a fresh branch of `deepseek-ai/deepseek-harness`. **Do not** use the PR #54 merge diff alone (`git diff cac4f790^1..cac4f790 …`) — verified 2026-08-27 that it does not apply to the upstream tree because `core/session` / `core/agent-loop` context includes `ddabf839`. Instead, from the desktop repo:
+
+  ```sh
+  git diff <pin.sha> HEAD:vendor/deepseek-harness -- \
+    packages/llm/llm packages/llm/llm-deepseek packages/llm/llm-pi-ai \
+    packages/core/agent-loop packages/core/session packages/core/tools \
+    packages/session/session-persistence-sqlite packages/extensions/tool-cordis \
+    'examples/acp-agent/tests/snapshots/empty-response-retry' \
+    '.agents/notes/implemented/bug-fix/2026-08-27-malformed-tool-call-recovery*' \
+    > handoff.patch
+  ```
+
+  Verified: `git apply -p1 --check handoff.patch` is clean on the rc.1 pin tree; on rc.2 use `git apply -p1 --3way handoff.patch` — exactly 2 files conflict (`packages/llm/llm-pi-ai/tests/convert.spec.ts`, `packages/llm/llm/README.i18n.yaml`; rc.2 touched the llm packages) and resolve trivially. Add the `ddabf839` Agent Note (`.agents/notes/implemented/bug-fix/2026-08-15-tool-call-result-pairing-recovery*`) to the pathspec if upstream wants both notes in one PR, or split the two fixes into a stack.
 - [ ] Run upstream gates on Node ^22.19 || >=24: `pnpm run test`, `pnpm run test:coverage` (per-file 100% on changed sources — verified locally 2026-08-27), `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`, `pnpm run test:snapshot`, `pnpm run doc-sync`.
 - [ ] Run real-API gates with `DEEPSEEK_API_KEY`: `pnpm run test:e2e` (blocked in the desktop CI environment — no key).
 - [ ] Open the upstream PR with one `kind/bug` label, `area/*` labels for llm / agent-loop / session / tools / session-persistence, and link the Agent Note.

--- a/docs/superpowers/plans/2026-08-27-dsh-tools-upstream-handoff.md
+++ b/docs/superpowers/plans/2026-08-27-dsh-tools-upstream-handoff.md
@@ -4,7 +4,7 @@
 
 **Do not** update `vendor/harness-upstream.json` until upstream has merged and tagged a release containing the fix; the pin records the integrated official baseline, never a pending PR.
 
-**Upstream status check (2026-08-27):** upstream has since tagged `dsh-v0.1.1-rc.2` (`b150a551`, current upstream HEAD). Verified it does **not** contain the fix (`requireValidToolCallIdentity` absent from `b150a551:packages/llm/llm/src/content.ts`), so this handoff is still pending; base the upstream branch on rc.2.
+**Upstream status check (2026-08-27):** upstream has since tagged `dsh-v0.1.1-rc.2` (`b150a551`, latest tag; HEAD keeps moving past it). Verified rc.2 does **not** contain the fix (`requireValidToolCallIdentity` absent from `b150a551:packages/llm/llm/src/content.ts`), so this handoff is still pending; base the upstream branch on rc.2 or newer.
 
 ## What the patch contains
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "qa:packaged": "node scripts/run-packaged-p0.mjs",
     "smoke:packaged": "node scripts/run-packaged-smoke.mjs",
     "check:release-version": "node scripts/check-release-version.mjs",
+    "check:fork-delta": "node scripts/check-harness-fork-delta.js",
+    "check:sync-dry-run": "node scripts/check-harness-sync-dry-run.js",
     "refresh:marketplace-snapshot": "node scripts/refresh-marketplace-snapshot.mjs",
     "dist": "node scripts/prepare-chisacode-remote.mjs --force --runtime && node scripts/run-electron-builder.cjs --win --publish never",
     "dist:mac": "node scripts/prepare-chisacode-remote.mjs --force --runtime && node scripts/run-electron-builder.cjs --mac --publish never"

--- a/scripts/check-harness-fork-delta.js
+++ b/scripts/check-harness-fork-delta.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { readPin, peelToCommit } = require('../src/shared/harness-upstream');
+const {
+  UNREGISTERED_BASELINE,
+  parseNameStatusZ,
+  buildReport,
+  unregisteredHotspots,
+  evaluateBaseline,
+} = require('../src/shared/harness-fork-delta');
+
+/**
+ * Fork-delta telemetry gate (decoupling Phase 0): diff the committed
+ * vendor/deepseek-harness tree against the upstream pin and classify every
+ * changed path against the fork registry in harness-desktop-forks.js.
+ * Fails when unregistered drift exceeds UNREGISTERED_BASELINE — new fork
+ * surface must either be registered or the baseline consciously raised in
+ * the same PR. Read-only; fetches the pin ref from upstream when the pin
+ * commit is not already in the local object store.
+ *
+ *   node scripts/check-harness-fork-delta.js [--json <path>] [--list-unregistered]
+ */
+
+const PREFIX = 'vendor/deepseek-harness';
+const root = path.join(__dirname, '..');
+
+function git(args) {
+  return spawnSync('git', args, { cwd: root, encoding: 'utf8', shell: false, maxBuffer: 64 * 1024 * 1024 });
+}
+
+function gitOk(args, message) {
+  const result = git(args);
+  if (result.status !== 0) {
+    throw new Error(message || `git ${args.join(' ')} failed: ${(result.stderr || result.stdout).trim()}`);
+  }
+  return result;
+}
+
+function parseArgs(argv) {
+  const parsed = { json: null, listUnregistered: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--json') {
+      parsed.json = argv[i + 1];
+      i += 1;
+      if (!parsed.json) {
+        throw new Error('--json requires a path');
+      }
+      continue;
+    }
+    if (argv[i] === '--list-unregistered') {
+      parsed.listUnregistered = true;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  return parsed;
+}
+
+function ensurePinCommit(pin) {
+  if (git(['cat-file', '-e', `${pin.sha}^{commit}`]).status === 0) {
+    return;
+  }
+  console.log(`pin commit ${pin.sha} not local; fetching ${pin.ref} from ${pin.repo}`);
+  gitOk(['fetch', pin.repo, pin.ref], `git fetch ${pin.repo} ${pin.ref} failed`);
+  let peeled;
+  try {
+    peeled = peelToCommit((args) => git(args), pin.ref);
+  } catch {
+    peeled = peelToCommit((args) => git(args), 'FETCH_HEAD');
+  }
+  if (peeled !== pin.sha) {
+    throw new Error(`fetched ${pin.ref} peels to ${peeled}, expected pin sha ${pin.sha}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pin = readPin(root);
+  ensurePinCommit(pin);
+
+  const raw = gitOk([
+    'diff-tree', '-r', '-z', '--name-status',
+    `${pin.sha}^{tree}`, `HEAD:${PREFIX}`,
+  ]).stdout;
+  const entries = parseNameStatusZ(raw);
+  const report = buildReport(entries);
+  const hotspots = unregisteredHotspots(report.unregistered.entries);
+  const verdict = evaluateBaseline(report);
+
+  console.log(`fork delta vs pin ${pin.ref} (${pin.sha.slice(0, 8)}): ${report.total} changed paths`);
+  for (const [bucket, count] of Object.entries(report.counts)) {
+    console.log(`  ${bucket}: ${count}`);
+  }
+  const byStatus = Object.entries(report.unregistered.byStatus)
+    .map(([status, count]) => `${status}=${count}`)
+    .join(' ');
+  console.log(`unregistered by status: ${byStatus || '(none)'}`);
+  console.log('unregistered hotspots:');
+  for (const { dir, count } of hotspots) {
+    console.log(`  ${String(count).padStart(5)}  ${dir}`);
+  }
+  if (args.listUnregistered) {
+    console.log('unregistered paths:');
+    for (const entry of report.unregistered.entries) {
+      console.log(`  ${entry.status}\t${entry.path}`);
+    }
+  }
+
+  if (args.json) {
+    const payload = {
+      pin,
+      baseline: UNREGISTERED_BASELINE,
+      total: report.total,
+      counts: report.counts,
+      unregistered: report.unregistered,
+      hotspots,
+      ok: verdict.ok,
+      failures: verdict.failures,
+      improvements: verdict.improvements,
+    };
+    fs.writeFileSync(args.json, `${JSON.stringify(payload, null, 2)}\n`);
+    console.log(`json report: ${args.json}`);
+  }
+
+  for (const note of verdict.improvements) {
+    console.log(`NOTE: ${note}`);
+  }
+  if (!verdict.ok) {
+    for (const failure of verdict.failures) {
+      console.error(`FAIL: ${failure}`);
+    }
+    process.exit(1);
+  }
+  console.log(`ok: unregistered drift within baseline (total<=${UNREGISTERED_BASELINE.total}, modified<=${UNREGISTERED_BASELINE.modified})`);
+}
+
+main();

--- a/scripts/check-harness-sync-dry-run.js
+++ b/scripts/check-harness-sync-dry-run.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { readPin, peelToCommit } = require('../src/shared/harness-upstream');
+const { syncHarness } = require('../src/shared/harness-sync');
+
+/**
+ * Scheduled upstream sync dry-run (decoupling Phase 0): price the next pin
+ * bump continuously instead of discovering it at upgrade time. Fetches the
+ * upstream target ref (default: upstream HEAD), replays the sync:harness
+ * subtree merge in --dry-run mode, and reports the conflict count. Report
+ * only: never bumps the pin, never leaves worktrees or refs behind (the
+ * dry-run path cleans both), and a conflicted merge still exits 0 — only
+ * infrastructure failures (fetch, dirty tree, merge machinery) exit 1.
+ *
+ *   node scripts/check-harness-sync-dry-run.js [--ref <upstream ref>] [--json <path>]
+ */
+
+const root = path.join(__dirname, '..');
+
+function git(args) {
+  return spawnSync('git', args, { cwd: root, encoding: 'utf8', shell: false, maxBuffer: 64 * 1024 * 1024 });
+}
+
+function parseArgs(argv) {
+  const parsed = { ref: 'HEAD', json: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--ref') {
+      parsed.ref = argv[i + 1];
+      i += 1;
+      if (!parsed.ref) {
+        throw new Error('--ref requires a value');
+      }
+      continue;
+    }
+    if (argv[i] === '--json') {
+      parsed.json = argv[i + 1];
+      i += 1;
+      if (!parsed.json) {
+        throw new Error('--json requires a path');
+      }
+      continue;
+    }
+    throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  return parsed;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const pin = readPin(root);
+
+  console.log(`fetching ${args.ref} from ${pin.repo}`);
+  const fetched = git(['fetch', pin.repo, args.ref]);
+  if (fetched.status !== 0) {
+    throw new Error(`git fetch ${pin.repo} ${args.ref} failed: ${(fetched.stderr || fetched.stdout).trim()}`);
+  }
+  const targetSha = peelToCommit((gitArgs) => git(gitArgs), 'FETCH_HEAD');
+  console.log(`pin: ${pin.ref} (${pin.sha.slice(0, 8)}) → target: ${args.ref} (${targetSha.slice(0, 8)})`);
+
+  let conflicts = [];
+  let upToDate = false;
+  if (targetSha === pin.sha) {
+    upToDate = true;
+    console.log('pin already at target; nothing to merge');
+  } else {
+    // syncHarness fetches by (ref, sha) itself; FETCH_HEAD survives from the
+    // resolve above, so pass the sha we just peeled. Symbolic HEAD does not
+    // peel inside the repo, so hand the sha as the ref too.
+    const syncRef = args.ref === 'HEAD' ? targetSha : args.ref;
+    const result = syncHarness({ root, args: { mode: 'sync', ref: syncRef, sha: targetSha, dryRun: true } });
+    if (result.status !== 'dry-run') {
+      throw new Error(`expected dry-run result, got ${result.status}`);
+    }
+    conflicts = result.conflicts || [];
+  }
+
+  console.log(`sync dry-run conflicts: ${conflicts.length}`);
+  for (const file of conflicts) {
+    console.log(`  ${file}`);
+  }
+
+  if (args.json) {
+    const payload = { pin, targetRef: args.ref, targetSha, upToDate, conflictCount: conflicts.length, conflicts };
+    fs.writeFileSync(args.json, `${JSON.stringify(payload, null, 2)}\n`);
+    console.log(`json report: ${args.json}`);
+  }
+  console.log(conflicts.length === 0
+    ? 'ok: upstream merges cleanly onto the vendored tree'
+    : 'report only: conflicts are the price of the next pin bump, not a failure');
+}
+
+main();

--- a/src/shared/dsh-webui-token-mirror.js
+++ b/src/shared/dsh-webui-token-mirror.js
@@ -1,0 +1,171 @@
+'use strict';
+
+/**
+ * Token mirror drift check (decoupling Phase 0): src/shared/dsh-webui-tokens.css
+ * hand-mirrors the official value table from
+ * vendor/deepseek-harness/packages/client/ui-theme/src/styles/design-platform.css
+ * for shells that cannot import ui-theme (launcher, boot, installer bitmaps).
+ * This module makes the parity machine-checked: parse both sheets, resolve the
+ * vendor var() chains to literal values, and compare every mirrored
+ * --dsw-alias-* / --dsw-static-* / --dsw-specific-* token in both themes.
+ * Tokens the mirror takes from other official sources (--ds-* motion/font,
+ * --dsw-shadow-*, --dsw-mask-blur, --dsw-font-family) are out of scope.
+ */
+
+const MIRRORED_TOKEN = /^--dsw-(alias|static|specific)-/;
+
+/**
+ * Parse flat CSS into { selector, decls } blocks. At-rule blocks (@media …)
+ * are skipped whole; both sheets keep compared tokens outside at-rules.
+ *
+ * @param {string} css
+ * @returns {{ selector: string, decls: Map<string, string> }[]}
+ */
+function parseBlocks(css) {
+  const text = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const blocks = [];
+  let i = 0;
+  while (i < text.length) {
+    const open = text.indexOf('{', i);
+    if (open === -1) {
+      break;
+    }
+    const selector = text.slice(i, open).trim();
+    let depth = 1;
+    let j = open + 1;
+    while (j < text.length && depth > 0) {
+      if (text[j] === '{') {
+        depth += 1;
+      } else if (text[j] === '}') {
+        depth -= 1;
+      }
+      j += 1;
+    }
+    if (depth !== 0) {
+      throw new Error(`unbalanced braces after selector ${JSON.stringify(selector)}`);
+    }
+    if (!selector.startsWith('@')) {
+      blocks.push({ selector, decls: parseDeclarations(text.slice(open + 1, j - 1)) });
+    }
+    i = j;
+  }
+  return blocks;
+}
+
+/**
+ * @param {string} body
+ * @returns {Map<string, string>} custom-property declarations only
+ */
+function parseDeclarations(body) {
+  const decls = new Map();
+  for (const raw of body.split(';')) {
+    const colon = raw.indexOf(':');
+    if (colon === -1) {
+      continue;
+    }
+    const name = raw.slice(0, colon).trim();
+    if (name.startsWith('--')) {
+      decls.set(name, raw.slice(colon + 1).trim());
+    }
+  }
+  return decls;
+}
+
+/**
+ * Merge the declarations of every block whose selector satisfies `match`,
+ * later blocks overriding earlier ones (source-order cascade at equal
+ * specificity, which is how both sheets are written).
+ *
+ * @param {{ selector: string, decls: Map<string, string> }[]} blocks
+ * @param {(selector: string) => boolean} match
+ * @returns {Map<string, string>}
+ */
+function mergeBlocks(blocks, match) {
+  const merged = new Map();
+  for (const block of blocks) {
+    if (match(block.selector)) {
+      for (const [name, value] of block.decls) {
+        merged.set(name, value);
+      }
+    }
+  }
+  return merged;
+}
+
+/**
+ * Resolve var(--x) references against a declaration table until the value is
+ * literal. Unknown references are left in place so the comparison reports
+ * them as a mismatch instead of hiding the drift.
+ *
+ * @param {string} value
+ * @param {Map<string, string>} table
+ * @returns {string}
+ */
+function resolveValue(value, table) {
+  let current = value;
+  for (let round = 0; round < 10; round += 1) {
+    const next = current.replace(/var\((--[\w-]+)\)/g, (whole, name) => (table.has(name) ? table.get(name) : whole));
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+  throw new Error(`var() chain too deep or cyclic in ${JSON.stringify(value)}`);
+}
+
+/** @param {string} value */
+function normalize(value) {
+  return value.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').replace(/\s*,\s*/g, ', ').trim();
+}
+
+const isDark = (selector) => selector.includes('data-ds-dark-theme');
+
+/**
+ * @param {string} mirrorCss  src/shared/dsh-webui-tokens.css contents
+ * @param {string} vendorCss  ui-theme design-platform.css contents
+ * @returns {{ checked: number, problems: { token: string, theme: 'light'|'dark', kind: 'missing-upstream'|'value-drift', mirror: string, vendor: string|null }[] }}
+ */
+function compareTokenMirror(mirrorCss, vendorCss) {
+  const mirrorBlocks = parseBlocks(mirrorCss);
+  const vendorBlocks = parseBlocks(vendorCss);
+
+  const vendorLight = mergeBlocks(vendorBlocks, (selector) => !isDark(selector));
+  const vendorDark = new Map([
+    ...vendorLight,
+    ...mergeBlocks(vendorBlocks, isDark),
+  ]);
+  const themes = [
+    { theme: 'light', mirror: mergeBlocks(mirrorBlocks, (selector) => !isDark(selector)), vendor: vendorLight },
+    { theme: 'dark', mirror: mergeBlocks(mirrorBlocks, isDark), vendor: vendorDark },
+  ];
+
+  const problems = [];
+  let checked = 0;
+  for (const { theme, mirror, vendor } of themes) {
+    for (const [token, mirrorValue] of mirror) {
+      if (!MIRRORED_TOKEN.test(token)) {
+        continue;
+      }
+      checked += 1;
+      if (!vendor.has(token)) {
+        problems.push({ token, theme, kind: 'missing-upstream', mirror: normalize(mirrorValue), vendor: null });
+        continue;
+      }
+      const vendorValue = normalize(resolveValue(vendor.get(token), vendor));
+      const mirrored = normalize(resolveValue(mirrorValue, mirror));
+      if (vendorValue !== mirrored) {
+        problems.push({ token, theme, kind: 'value-drift', mirror: mirrored, vendor: vendorValue });
+      }
+    }
+  }
+  return { checked, problems };
+}
+
+module.exports = {
+  MIRRORED_TOKEN,
+  parseBlocks,
+  mergeBlocks,
+  resolveValue,
+  normalize,
+  compareTokenMirror,
+};

--- a/src/shared/dsh-webui-token-mirror.test.js
+++ b/src/shared/dsh-webui-token-mirror.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  parseBlocks,
+  mergeBlocks,
+  resolveValue,
+  normalize,
+  compareTokenMirror,
+} = require('./dsh-webui-token-mirror');
+
+test('parseBlocks keeps custom properties per selector and skips at-rules', () => {
+  const blocks = parseBlocks(`
+    /* comment { with brace */
+    :root { --a: rgb(1, 2, 3); color-scheme: light; --b: var(--a); }
+    @media (prefers-reduced-motion: reduce) { :root { --a: none; } }
+    body[data-ds-dark-theme] { --a: rgb(4, 5, 6); }
+  `);
+  assert.deepEqual(blocks.map((block) => block.selector), [':root', 'body[data-ds-dark-theme]']);
+  assert.equal(blocks[0].decls.get('--a'), 'rgb(1, 2, 3)');
+  assert.equal(blocks[0].decls.get('--b'), 'var(--a)');
+  assert.equal(blocks[0].decls.has('color-scheme'), false);
+  assert.equal(blocks[1].decls.get('--a'), 'rgb(4, 5, 6)');
+});
+
+test('parseBlocks rejects unbalanced braces', () => {
+  assert.throws(() => parseBlocks('body { --a: 1;'), /unbalanced/);
+});
+
+test('mergeBlocks lets later blocks override earlier ones', () => {
+  const blocks = parseBlocks('body { --a: 1; --b: 2; } body { --a: 3; }');
+  const merged = mergeBlocks(blocks, (selector) => selector === 'body');
+  assert.equal(merged.get('--a'), '3');
+  assert.equal(merged.get('--b'), '2');
+});
+
+test('resolveValue follows var() chains and leaves unknown references', () => {
+  const table = new Map([
+    ['--base', 'rgb(1, 2, 3)'],
+    ['--alias', 'var(--base)'],
+    ['--pct', '80%'],
+  ]);
+  assert.equal(resolveValue('var(--alias)', table), 'rgb(1, 2, 3)');
+  assert.equal(
+    resolveValue('color-mix(in srgb, var(--base) var(--pct), transparent)', table),
+    'color-mix(in srgb, rgb(1, 2, 3) 80%, transparent)',
+  );
+  assert.equal(resolveValue('var(--nope)', table), 'var(--nope)');
+});
+
+test('resolveValue rejects cyclic chains', () => {
+  const table = new Map([['--x', 'var(--y)'], ['--y', 'var(--x)']]);
+  assert.throws(() => resolveValue('var(--x)', table), /cyclic/);
+});
+
+test('normalize collapses whitespace inside multi-line values', () => {
+  assert.equal(
+    normalize('0 0 1px 0 rgba(0, 0, 0, 0.2),\n    0 12px 32px 0 rgba(0,0,0,0.08)'),
+    '0 0 1px 0 rgba(0, 0, 0, 0.2), 0 12px 32px 0 rgba(0, 0, 0, 0.08)',
+  );
+});
+
+test('compareTokenMirror flags value drift and missing upstream tokens per theme', () => {
+  const mirror = `
+    :root { --dsw-alias-bg-base: rgb(255, 255, 255); --dsw-alias-gone: rgb(0, 0, 0); --ds-not-checked: 1s; }
+    html[data-ds-dark-theme] { --dsw-alias-bg-base: rgb(0, 0, 0); }
+  `;
+  const vendor = `
+    body { --dsw-static-white: rgb(255, 255, 255); --dsw-alias-bg-base: var(--dsw-static-white); }
+    body[data-ds-dark-theme] { --dsw-alias-bg-base: rgb(21, 21, 23); }
+  `;
+  const result = compareTokenMirror(mirror, vendor);
+  assert.equal(result.checked, 3);
+  assert.deepEqual(result.problems, [
+    { token: '--dsw-alias-gone', theme: 'light', kind: 'missing-upstream', mirror: 'rgb(0, 0, 0)', vendor: null },
+    { token: '--dsw-alias-bg-base', theme: 'dark', kind: 'value-drift', mirror: 'rgb(0, 0, 0)', vendor: 'rgb(21, 21, 23)' },
+  ]);
+});
+
+test('compareTokenMirror resolves the dark table over the light cascade', () => {
+  const mirror = 'html[data-ds-dark-theme] { --dsw-specific-menu: color-mix(in srgb, rgb(53, 54, 56) 80%, transparent); }';
+  const vendor = `
+    body { --dsw-alias-glass-opacity: 80%; --dsw-specific-menu: color-mix(in srgb, var(--layer) var(--dsw-alias-glass-opacity), transparent); --layer: rgb(255, 255, 255); }
+    body[data-ds-dark-theme] { --layer: rgb(53, 54, 56); }
+  `;
+  const result = compareTokenMirror(mirror, vendor);
+  assert.equal(result.checked, 1);
+  assert.deepEqual(result.problems, []);
+});
+
+// The real gate: the hand-mirrored shell token sheet must match the official
+// ui-theme value table (design-language mandate; decoupling analysis §6.5).
+test('src/shared/dsh-webui-tokens.css matches ui-theme design-platform.css', () => {
+  const root = path.join(__dirname, '..', '..');
+  const mirror = fs.readFileSync(path.join(root, 'src', 'shared', 'dsh-webui-tokens.css'), 'utf8');
+  const vendor = fs.readFileSync(
+    path.join(root, 'vendor', 'deepseek-harness', 'packages', 'client', 'ui-theme', 'src', 'styles', 'design-platform.css'),
+    'utf8',
+  );
+  const result = compareTokenMirror(mirror, vendor);
+  assert.ok(result.checked >= 60, `expected to check at least 60 mirrored tokens, saw ${result.checked}`);
+  assert.deepEqual(
+    result.problems,
+    [],
+    'dsh-webui-tokens.css drifted from design-platform.css — re-mirror the flagged tokens (both themes)',
+  );
+});

--- a/src/shared/harness-fork-delta.js
+++ b/src/shared/harness-fork-delta.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const { DESKTOP_PACKAGES, FORK_FILE_MARKERS, COMPOSITION_ROWS } = require('./harness-desktop-forks');
+
+/**
+ * Fork-delta classification: every path in `git diff` between the upstream
+ * pin tree and `HEAD:vendor/deepseek-harness` falls into exactly one bucket.
+ *
+ * - registered-package: under a DESKTOP_PACKAGES dir (whole desktop-owned package)
+ * - composition:        a COMPOSITION_ROWS patch file (desktop rows in upstream bundles)
+ * - marked-file:        a FORK_FILE_MARKERS path (file-level fork in an upstream package)
+ * - unregistered:       fork drift no registry entry accounts for
+ */
+const BUCKETS = ['registered-package', 'marked-file', 'composition', 'unregistered'];
+
+/**
+ * Unregistered-drift baseline, measured 2026-08-27 on main@581547eb against
+ * pin dsh-v0.1.1-rc.1 @ 528c682e061696f5a160f363f236ecbf53cbd006:
+ * 1,372 changed paths → 431 registered-package, 18 marked-file, 2 composition,
+ * 921 unregistered (306 added, 604 modified upstream files, 8 type changes,
+ * 3 deleted). `modified` is the decoupling-analysis §6.1 gap (estimated ~605)
+ * made machine-readable. The gate fails only when a count EXCEEDS its
+ * baseline; when drift shrinks (fork edits upstreamed or registered), lower
+ * the matching number here in the same PR so the ratchet holds.
+ */
+const UNREGISTERED_BASELINE = { total: 921, modified: 604 };
+
+const packageDirPrefixes = DESKTOP_PACKAGES.map((pkg) => `${pkg.dir}/`);
+const compositionFiles = new Set(COMPOSITION_ROWS.map((row) => row.file));
+const markedFiles = new Set(FORK_FILE_MARKERS.map((marker) => marker.file));
+
+/**
+ * @param {string} relPath path relative to the vendor root, forward slashes
+ * @returns {'registered-package'|'marked-file'|'composition'|'unregistered'}
+ */
+function classifyPath(relPath) {
+  if (packageDirPrefixes.some((prefix) => relPath.startsWith(prefix))) {
+    return 'registered-package';
+  }
+  if (compositionFiles.has(relPath)) {
+    return 'composition';
+  }
+  if (markedFiles.has(relPath)) {
+    return 'marked-file';
+  }
+  return 'unregistered';
+}
+
+/**
+ * Parse NUL-separated `git diff-tree -r -z --name-status` output into
+ * { status, path } entries. Statuses are single letters (A/M/D/T…); rename
+ * detection is off between plain trees so no R scores appear.
+ *
+ * @param {string} raw
+ * @returns {{ status: string, path: string }[]}
+ */
+function parseNameStatusZ(raw) {
+  const tokens = raw.split('\0').filter((token) => token !== '');
+  if (tokens.length % 2 !== 0) {
+    throw new Error(`name-status stream has ${tokens.length} tokens; expected status/path pairs`);
+  }
+  const entries = [];
+  for (let i = 0; i < tokens.length; i += 2) {
+    const status = tokens[i];
+    if (!/^[A-Z]$/.test(status)) {
+      throw new Error(`unexpected diff status ${JSON.stringify(status)} for ${tokens[i + 1]}`);
+    }
+    entries.push({ status, path: tokens[i + 1] });
+  }
+  return entries;
+}
+
+/**
+ * @param {{ status: string, path: string }[]} entries
+ * @returns {{
+ *   total: number,
+ *   counts: Record<string, number>,
+ *   unregistered: { total: number, byStatus: Record<string, number>, entries: { status: string, path: string }[] },
+ * }}
+ */
+function buildReport(entries) {
+  const counts = Object.fromEntries(BUCKETS.map((bucket) => [bucket, 0]));
+  const unregistered = [];
+  for (const entry of entries) {
+    const bucket = classifyPath(entry.path);
+    counts[bucket] += 1;
+    if (bucket === 'unregistered') {
+      unregistered.push(entry);
+    }
+  }
+  const byStatus = {};
+  for (const entry of unregistered) {
+    byStatus[entry.status] = (byStatus[entry.status] || 0) + 1;
+  }
+  return {
+    total: entries.length,
+    counts,
+    unregistered: { total: unregistered.length, byStatus, entries: unregistered },
+  };
+}
+
+/**
+ * Top directories carrying unregistered drift (packages keyed at
+ * packages/<group>/<name>, everything else at its first two segments).
+ *
+ * @param {{ status: string, path: string }[]} entries
+ * @param {number} [limit]
+ * @returns {{ dir: string, count: number }[]}
+ */
+function unregisteredHotspots(entries, limit = 15) {
+  const counts = new Map();
+  for (const entry of entries) {
+    const parts = entry.path.split('/');
+    const depth = parts[0] === 'packages' ? 3 : 2;
+    const key = parts.slice(0, Math.min(depth, parts.length)).join('/');
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([dir, count]) => ({ dir, count }))
+    .sort((a, b) => b.count - a.count || a.dir.localeCompare(b.dir))
+    .slice(0, limit);
+}
+
+/**
+ * Ratchet verdict: fail when unregistered drift exceeds the recorded
+ * baseline; flag (without failing) when it shrank so the baseline gets
+ * lowered.
+ *
+ * @param {{ unregistered: { total: number, byStatus: Record<string, number> } }} report
+ * @param {{ total: number, modified: number }} [baseline]
+ * @returns {{ ok: boolean, failures: string[], improvements: string[] }}
+ */
+function evaluateBaseline(report, baseline = UNREGISTERED_BASELINE) {
+  const failures = [];
+  const improvements = [];
+  const total = report.unregistered.total;
+  const modified = report.unregistered.byStatus.M || 0;
+  if (total > baseline.total) {
+    failures.push(`unregistered paths grew: ${total} > baseline ${baseline.total} — register the new fork surface in src/shared/harness-desktop-forks.js (DESKTOP_PACKAGES / FORK_FILE_MARKERS / COMPOSITION_ROWS) or revert the vendor drift`);
+  } else if (total < baseline.total) {
+    improvements.push(`unregistered paths shrank: ${total} < baseline ${baseline.total} — lower UNREGISTERED_BASELINE.total in src/shared/harness-fork-delta.js to hold the ratchet`);
+  }
+  if (modified > baseline.modified) {
+    failures.push(`unregistered modified upstream files grew: ${modified} > baseline ${baseline.modified}`);
+  } else if (modified < baseline.modified) {
+    improvements.push(`unregistered modified upstream files shrank: ${modified} < baseline ${baseline.modified} — lower UNREGISTERED_BASELINE.modified`);
+  }
+  return { ok: failures.length === 0, failures, improvements };
+}
+
+module.exports = {
+  BUCKETS,
+  UNREGISTERED_BASELINE,
+  classifyPath,
+  parseNameStatusZ,
+  buildReport,
+  unregisteredHotspots,
+  evaluateBaseline,
+};

--- a/src/shared/harness-fork-delta.test.js
+++ b/src/shared/harness-fork-delta.test.js
@@ -90,8 +90,8 @@ test('unregisteredHotspots groups packages three segments deep, others two', () 
   ]);
   assert.deepEqual(hotspots, [
     { dir: 'packages/client/ui-conversation', count: 2 },
-    { dir: 'CLAUDE.md', count: 1 },
     { dir: 'apps/web', count: 1 },
+    { dir: 'CLAUDE.md', count: 1 },
   ]);
 });
 

--- a/src/shared/harness-fork-delta.test.js
+++ b/src/shared/harness-fork-delta.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  BUCKETS,
+  UNREGISTERED_BASELINE,
+  classifyPath,
+  parseNameStatusZ,
+  buildReport,
+  unregisteredHotspots,
+  evaluateBaseline,
+} = require('./harness-fork-delta');
+
+test('classifyPath sends registered package dirs to registered-package', () => {
+  assert.equal(classifyPath('packages/client/ui-titlebar/src/client/Titlebar.tsx'), 'registered-package');
+  assert.equal(classifyPath('packages/host/mcp-servers/package.json'), 'registered-package');
+  assert.equal(classifyPath('packages/mcp/mcp-servers-file/src/index.ts'), 'registered-package');
+});
+
+test('classifyPath does not prefix-match a lookalike sibling directory', () => {
+  // 'packages/client/ui-git/' must not swallow 'ui-git-extras'.
+  assert.equal(classifyPath('packages/client/ui-git-extras/src/index.ts'), 'unregistered');
+  // The bare package dir path itself (no trailing segment) is not a file diff
+  // entry, but a same-named file outside the dir stays unregistered.
+  assert.equal(classifyPath('packages/client/ui-git.md'), 'unregistered');
+});
+
+test('classifyPath sends composition patch files to composition', () => {
+  assert.equal(classifyPath('packages/bundle/base/cordis.patch.yml'), 'composition');
+  assert.equal(classifyPath('packages/bundle/web-app/cordis.patch.yml'), 'composition');
+});
+
+test('classifyPath sends FORK_FILE_MARKERS paths to marked-file', () => {
+  assert.equal(classifyPath('apps/cli/src/args.ts'), 'marked-file');
+  assert.equal(classifyPath('packages/client/ui-primitives/src/index.ts'), 'marked-file');
+  assert.equal(classifyPath('package.json'), 'marked-file');
+});
+
+test('classifyPath defaults to unregistered', () => {
+  assert.equal(classifyPath('apps/web/src/main.tsx'), 'unregistered');
+  assert.equal(classifyPath('.agents/notes/implemented/feature/x.md'), 'unregistered');
+});
+
+test('parseNameStatusZ parses NUL-separated status/path pairs', () => {
+  const raw = 'M\0apps/web/src/main.tsx\0A\0packages/client/ui-git/src/new.ts\0D\0old.txt\0';
+  assert.deepEqual(parseNameStatusZ(raw), [
+    { status: 'M', path: 'apps/web/src/main.tsx' },
+    { status: 'A', path: 'packages/client/ui-git/src/new.ts' },
+    { status: 'D', path: 'old.txt' },
+  ]);
+});
+
+test('parseNameStatusZ rejects odd token streams and non-letter statuses', () => {
+  assert.throws(() => parseNameStatusZ('M\0only-status-then-nothing\0M\0'), /pairs/);
+  assert.throws(() => parseNameStatusZ('R100\0a\0'), /unexpected diff status/);
+});
+
+test('buildReport counts every bucket and collects unregistered entries', () => {
+  const report = buildReport([
+    { status: 'A', path: 'packages/client/ui-titlebar/src/index.ts' },
+    { status: 'M', path: 'packages/bundle/web-app/cordis.patch.yml' },
+    { status: 'M', path: 'apps/cli/src/args.ts' },
+    { status: 'M', path: 'apps/web/src/main.tsx' },
+    { status: 'A', path: 'apps/web/src/desktop-extra.tsx' },
+    { status: 'T', path: 'CLAUDE.md' },
+  ]);
+  assert.equal(report.total, 6);
+  assert.deepEqual(report.counts, {
+    'registered-package': 1,
+    'marked-file': 1,
+    composition: 1,
+    unregistered: 3,
+  });
+  assert.deepEqual(report.unregistered.byStatus, { M: 1, A: 1, T: 1 });
+  assert.deepEqual(report.unregistered.entries.map((entry) => entry.path), [
+    'apps/web/src/main.tsx',
+    'apps/web/src/desktop-extra.tsx',
+    'CLAUDE.md',
+  ]);
+});
+
+test('unregisteredHotspots groups packages three segments deep, others two', () => {
+  const hotspots = unregisteredHotspots([
+    { status: 'M', path: 'packages/client/ui-conversation/src/a.tsx' },
+    { status: 'M', path: 'packages/client/ui-conversation/tests/b.spec.tsx' },
+    { status: 'M', path: 'apps/web/src/main.tsx' },
+    { status: 'T', path: 'CLAUDE.md' },
+  ]);
+  assert.deepEqual(hotspots, [
+    { dir: 'packages/client/ui-conversation', count: 2 },
+    { dir: 'CLAUDE.md', count: 1 },
+    { dir: 'apps/web', count: 1 },
+  ]);
+});
+
+test('evaluateBaseline passes at the baseline and fails above it', () => {
+  const atBaseline = evaluateBaseline(
+    { unregistered: { total: 10, byStatus: { M: 6, A: 4 } } },
+    { total: 10, modified: 6 },
+  );
+  assert.equal(atBaseline.ok, true);
+  assert.deepEqual(atBaseline.failures, []);
+  assert.deepEqual(atBaseline.improvements, []);
+
+  const grewTotal = evaluateBaseline(
+    { unregistered: { total: 11, byStatus: { M: 6, A: 5 } } },
+    { total: 10, modified: 6 },
+  );
+  assert.equal(grewTotal.ok, false);
+  assert.match(grewTotal.failures[0], /11 > baseline 10/);
+
+  const grewModified = evaluateBaseline(
+    { unregistered: { total: 10, byStatus: { M: 7, A: 3 } } },
+    { total: 10, modified: 6 },
+  );
+  assert.equal(grewModified.ok, false);
+  assert.match(grewModified.failures[0], /7 > baseline 6/);
+});
+
+test('evaluateBaseline reports improvements without failing', () => {
+  const shrank = evaluateBaseline(
+    { unregistered: { total: 8, byStatus: { M: 5, A: 3 } } },
+    { total: 10, modified: 6 },
+  );
+  assert.equal(shrank.ok, true);
+  assert.equal(shrank.improvements.length, 2);
+  assert.match(shrank.improvements[0], /lower UNREGISTERED_BASELINE.total/);
+});
+
+test('baseline constants stay in the documented shape', () => {
+  assert.deepEqual(BUCKETS, ['registered-package', 'marked-file', 'composition', 'unregistered']);
+  assert.equal(typeof UNREGISTERED_BASELINE.total, 'number');
+  assert.equal(typeof UNREGISTERED_BASELINE.modified, 'number');
+  assert.ok(UNREGISTERED_BASELINE.modified <= UNREGISTERED_BASELINE.total);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Phase 0 decoupling instrumentation** per `docs/superpowers/plans/2026-08-27-dsh-decoupling-analysis.md`. No product behavior, vendor pin, or coupling severed — boundary telemetry and gates only.

### Shipped
- **Fork-delta classifier** (`npm run check:fork-delta`) — classifies diff vs upstream pin into registered / marked / composition / **unregistered** buckets; CI `fork-delta` job fails if drift exceeds baseline (**921 total / 604 modified upstream files**)
- **Upstream sync dry-run sentinel** — `npm run check:sync-dry-run` + weekly `harness-sync-dry-run.yml` workflow (report-only)
- **Token mirror gate** — machine-checks `dsh-webui-tokens.css` vs `design-platform.css` (63 tokens, both themes) in `npm test`
- **Sidecar-by-default policy** in Feature Spine README
- **dsh-tools handoff doc corrected** — verified cumulative diff applies to upstream rc.2 (2 trivial 3-way conflicts)

### Measured drift (baseline)
| Bucket | Count |
|--------|-------|
| registered-package | 431 |
| marked-file | 18 |
| composition | 2 |
| **unregistered** | **921** (604 modified upstream) |

Sync dry-run: **20 conflicts** vs `dsh-v0.1.1-rc.2`; upstream HEAD already at **311 conflicts**.

See `docs/superpowers/plans/2026-08-27-dsh-decoupling-phase0-execution.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a7e50e9-d34b-47fe-b1f1-9e55f6abaebd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a7e50e9-d34b-47fe-b1f1-9e55f6abaebd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

