### PR TITLE
fix: convert prestart-ensure.mjs to ESM so npm start runs

### DIFF
--- a/scripts/prestart-ensure.mjs
+++ b/scripts/prestart-ensure.mjs
@@ -1,14 +1,13 @@
-'use strict';
-
 /**
  * Ensure runtime artifacts match latest source before Electron starts.
  * Stops shipping stale ui-settings-remote/lib or missing ChisaCode links.
  */
-const fs = require('fs');
-const path = require('path');
-const { spawnSync } = require('child_process');
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-const root = path.join(__dirname, '..');
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 function newestMtime(dir, filter) {
   let newest = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `scripts/prestart-ensure.mjs` used CommonJS `require` under an `.mjs` extension, so Node rejected it and `npm start` failed on latest `main`.
- Converted the script to ESM (`node:` imports + `import.meta.url`) to match sibling scripts such as `prepare-chisacode-remote.mjs`.

## Test plan
- [x] `node scripts/prestart-ensure.mjs` exits 0
- [ ] `npm start` launches Electron on cloud Linux (`DISPLAY=:1`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f23200db-46f3-43c5-a696-76ec13f85af2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f23200db-46f3-43c5-a696-76ec13f85af2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

