### PR TITLE
chore(cloud-env): make .cursor install produce a runnable dev VM

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -25,4 +25,15 @@ fi
 node --version
 
 npm ci
-node node_modules/pnpm/bin/pnpm.cjs --dir vendor/deepseek-harness install --frozen-lockfile
+
+# .npmrc pins electron_skip_binary_download=true so packaging via electron-builder
+# stays deterministic, but a source-run dev VM still needs the Electron runtime
+# binary to launch `npm start` / the smoke + QA walks. Extract it from the cache
+# (idempotent; no-op when dist already matches).
+node node_modules/electron/install.js
+
+# Build the vendored harness so the app runs from source, not just enough for the
+# desktop-shell unit tests: setup:harness runs the vendor pnpm install
+# (--frozen-lockfile), builds the client libs, stages the Ghostty terminal assets,
+# and installs the bundled plugin runtime deps. It is idempotent.
+npm run setup:harness


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The committed Cloud Agent setup (`.cursor/environment.json` → `.cursor/install.sh`) only refreshed dependencies. That is enough for the desktop-shell unit tests (`npm test`), but it does **not** produce a VM that can actually launch the app:

- `.npmrc` pins `electron_skip_binary_download=true` (so `electron-builder` packaging stays deterministic), which means `npm ci` never fetches the Electron **runtime** binary. `npm start` / the smoke + QA walks then fail with *"未找到本机 Electron"*.
- The vendored harness client libraries (`vendor/deepseek-harness/packages/client/*/lib`) are not prebuilt, so the source-run UI has nothing to load.

## What

Extend `.cursor/install.sh` (after `npm ci`) to:

1. Extract the Electron runtime binary from cache — `node node_modules/electron/install.js` (idempotent; no-op when `dist` already matches).
2. Build the vendored harness — `npm run setup:harness` (vendor `pnpm install --frozen-lockfile`, client lib build, Ghostty terminal assets, bundled plugin runtime deps). Idempotent.

This replaces the standalone `pnpm --dir vendor/deepseek-harness install` line, since `setup:harness` already runs that install.

With environment **builds**, `install` runs once to seed the snapshot, so the extra build cost is paid at build time rather than on every agent boot.

## Validation (on the Cloud Agent VM)

- `bash .cursor/install.sh` run twice → both exit `0` (idempotent); Electron binary + client libs present afterward.
- `npm test` → **1224 passing**, 0 failing, 5 skipped.
- `npm run qa:source` (Xvfb) → **passed**, full release UI walk (titlebar, terminal, git commit, surfaces/Files/Diff/Browser, settings, appearance, wallpaper gallery, models, MCP, skills, marketplace, usage-stats).
- `npm run smoke:source` (Xvfb) → **passed** (frame + titlebar hits + PTY `echoed:ok`).

Screenshot of the app running from source in the VM:

[Deepseek-Harness-Desktop running from source in the Cloud Agent VM](https://cursor.com/agents/bc-f67fe339-b057-4ab4-8123-7f4d16056732/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdshd-qa-source.png)

Note: `smoke:source`'s standalone titlebar branch-menu probe (a 5s CDP menu-open wait) is timing-flaky under headless Xvfb; the more comprehensive `qa:source` walk exercises the same git menu and passes reliably.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f67fe339-b057-4ab4-8123-7f4d16056732?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f67fe339-b057-4ab4-8123-7f4d16056732&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

