### PR TITLE
feature(mobile-remote): rebuild SQLite runtime for Electron

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,13 @@
 name: Build installers
 
 on:
-  workflow_dispatch: # 手动触发，产出安装包 artifacts
+  workflow_dispatch:
+    inputs:
+      include_macos:
+        description: Build the optional macOS artifact
+        required: false
+        type: boolean
+        default: false
   push:
     tags: ['v*'] # 打 tag 时构建并发布 GitHub Release
 
@@ -69,6 +75,9 @@ jobs:
           if-no-files-found: error
 
   macos:
+    # Manual candidate builds are Windows-only unless explicitly requested.
+    # Tag builds keep the historical best-effort macOS behavior.
+    if: ${{ github.event_name == 'push' || inputs.include_macos }}
     runs-on: macos-latest
     timeout-minutes: 120
     env:

--- a/docs/features/mobile-remote.md
+++ b/docs/features/mobile-remote.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `mobile-remote` |
 | **status** | `active` |
-| **last verified** | 2026-09-05 — 本地 Web + host tunnel/mux 304/304；假 host 浏览器 30/30；Android JVM 测试和 Debug APK 构建此前通过。用户授权后仅启用本机目录模块并重启远程：217 条会话约 62.6KB，公网直连及系统代理各新配对 + 5 次重连，共 12 次目录加载成功，4955–13476ms，无目录超时。公网页面另有一次导航超时，不能宣称任意弱网稳定。无正式发布、无公网前端追加部署、无 APK 安装；ADB 无设备，Android 实机 Blocked。入口已开放但最终 CI 安装包全量验收待完成，**不得写「实机全量通过」**。 |
+| **last verified** | 2026-09-06 — Windows 0.2.9 候选发现生产 runtime 漏装 `better-sqlite3.node`；`prepare-chisacode-remote.mjs --runtime` 现仅重建 `better-sqlite3` 到 Electron 43.4.0 / Node ABI 148，并立即执行内存 SQLite 读写探针，失败即阻断 `npm run dist`。本地从空 runtime 重建、`npm test` 1402 pass / 2 skip、NSIS 构建、产物 ABI 探针和 packaged smoke 均通过。产品负责人明确本次 Windows 发布忽略 Web 第二客户端与 Android 验收；相关轨道记范围外/豁免，**不记 Pass，也不宣称实机全量通过**。此前：2026-09-05 — 本地 Web + host tunnel/mux 304/304；假 host 浏览器 30/30；Android JVM 测试和 Debug APK 构建此前通过。 |
 
 ## User paths
 

--- a/docs/features/windows-installer.md
+++ b/docs/features/windows-installer.md
@@ -4,7 +4,7 @@
 | --- | --- |
 | **id** | `windows-installer` |
 | **status** | `active` |
-| **last verified** | 2026-09-03 — **实机首启「未响应」修复**：alpha.4 安装包装后首启，Windows 弹出「Deepseek-Harness-Desktop 未响应」（WER `AppHangTransient` 08:05:29）。取证：启动链上两处主线程同步 IO——`usage-panel-preset` 每次全量启动 `fs.cpSync` 约 6k 文件的插件包（实机 11.4 s，空载复测 4.5 s），以及 `harness-extract` 覆盖/升级安装时 `fs.rmSync` 上一份约 57k 文件的 `runtime/<version>`（空载复测 16 s，实机窗口 46 s）——都超过 Windows 5 s 挂起阈值。修复：插件包改 `fs.promises.cp` 增量复制（size+mtime 相同即跳过，保留时间戳）；旧运行时改 rename 到 `runtime/<version>.stale-*` 后台异步删除，启动时清扫上次未删完的残留；tar 解压本就是异步子进程。静态断言钉死两处不得回退到 `cpSync`/`rmSync`。`npm test` 1466 通过 / 2 skip。此前本轮 alpha.4：本地 NSIS 安装包已生成并通过 packaged P0；未发布。此前 2026-08-26 — D4 发布链验收：release.yml windows job 在 `npm run dist` 与 artifact 上传之间新增**阻断式** packaged smoke 门禁（`npm run smoke:packaged` 实启 `dist/win-unpacked`，两次尝试吸收单次 flake，策略写进 workflow 注释；macos job 保持 best-effort 无 smoke）；该步骤是**产物验收**而非重复 test.yml 质量门（smoke 需要 dist 产物，只能存在于发布链），推翻 d9481ce7 的「release 不跑 smoke:packaged」钉子，新位置由 `ci-isolation.test.js` 钉死（dist 之后、上传之前、含重试、无 continue-on-error）。**首个 tag 前须经 `workflow_dispatch` 手动跑一轮 windows job 验证该步骤本身（本轮在 Linux VM 上未实跑 Windows smoke，不作已验证声称）。** 此前 2026-08-25 — 第三轮：`customUnWelcomePage` 修复卸载欢迎页 3 行标题裁字（契约决策 A，机制核对到 MUI2 源码；wine+Xvfb 修后截图见 [QA 证据](../qa/results/2026-08-25/installer-branding/EXECUTION-REPORT.md)），门禁 8/8、`npm test` 全绿；完成页/真实 `/S`/zh_CN 仍待 CI windows artifact 实机走查，清单固化在 [TC-INST-RUNBOOK.md](../qa/results/2026-08-25/installer-branding/TC-INST-RUNBOOK.md)（workflow dispatch 云代理 403，须人触发） |
+| **last verified** | 2026-09-06 — Windows 0.2.9 本地候选已完成 `npm test`（1402 pass / 2 skip）、NSIS 构建、Electron 43 / ABI 148 SQLite 读写探针与 packaged smoke；Setup SHA256 `fe3d16de40981980f9d03ac607cb7f385c6ccc74c8b18bed2ee928eaffee62ed`。产品负责人明确本版不发布 macOS，手动候选工作流默认只构建 Windows；Web 第二客户端与 Android 同样不计入本版验收。CI 同 SHA 候选仍待生成，未发布。 |
 
 ## User paths
 
@@ -21,7 +21,7 @@
 - 安装器语言 zh_CN（首位 = 兜底）+ en_US；产品中文文案走 MUI 本地化串，不烙进位图。
 - 许可页读根 `LICENSE`（MIT）原文。
 - 安装器/卸载器图标 = `assets/icon.ico`（与应用同一鲸标）。
-- 发布链产物验收：windows job 的 packaged smoke 门禁（`smoke:packaged` on `dist/win-unpacked`）位于 `npm run dist` 之后、artifact 上传之前，**阻断**发版；步骤内置两次尝试（连续两次失败=真问题），不设 `continue-on-error`；macos job 不加 smoke（best-effort 政策不变）。不得把该步骤改造成重复 test.yml 的质量门（`npm test` / `test:gui` 仍禁止进 release.yml）。
+- 发布链产物验收：windows job 的 packaged smoke 门禁（`smoke:packaged` on `dist/win-unpacked`）位于 `npm run dist` 之后、artifact 上传之前，**阻断**发版；步骤内置两次尝试（连续两次失败=真问题），不设 `continue-on-error`。`workflow_dispatch` 默认只构建 Windows；macOS 仅在显式 `include_macos=true` 时构建。本版 Windows 发布不上传 DMG。不得把该步骤改造成重复 test.yml 的质量门（`npm test` / `test:gui` 仍禁止进 release.yml）。
 
 ## Allowed touch
 
@@ -29,20 +29,20 @@
 - `build/` — `installer.nsh` 与生成的 BMP
 - `scripts/render-installer-assets.js`、`scripts/run-render-installer-assets.js` — 位图生成
 - `src/main/installer-branding.test.js` — 自动门禁
-- `.github/workflows/release.yml` windows job 的 packaged smoke 步骤与 `src/main/ci-isolation.test.js` 对应钉子（2026-08-26 扩入，理由：发布链产物验收属本卡；上传 globs / SHA512SUMS 流仍在 Do not touch）
+- `.github/workflows/release.yml` windows job 的 packaged smoke、手动候选的 Windows-only 默认值与 `src/main/ci-isolation.test.js` 对应钉子（2026-09-06 用户明确要求本版不要 macOS；上传 globs / SHA512SUMS 流仍在 Do not touch）
 - 本卡与 [build-release handbook](../handbook/modules/build-release.md)
 
 ## Do not touch
 
 - `scripts/after-pack.js` 装配逻辑、SHA512SUMS / 更新器校验流
 - artifact 命名与 `release.yml` 上传 globs
-- mac DMG 配置（次要产物，独立演进）
+- mac DMG 打包配置与上传命名；本卡只控制手动工作流是否调度既有 macOS job
 
 ## Gates
 
 | Kind | What |
 | --- | --- |
-| Automated | `node --test src/main/installer-branding.test.js`（随 `npm test`）：nsis 契约、BMP 几何/位深、nsh 宏白名单、release.yml glob 对齐；`ci-isolation.test.js` 钉 packaged smoke 门禁位置（dist 后、上传前、两次尝试、无 continue-on-error）；release CI 实跑 `smoke:packaged`（win-unpacked 实启 + 内嵌 DSH_SMOKE 断言，阻断发版） |
+| Automated | `node --test src/main/installer-branding.test.js src/main/ci-isolation.test.js`（随 `npm test`）：nsis 契约、BMP 几何/位深、nsh 宏白名单、release.yml glob 对齐；手动候选默认 Windows-only；packaged smoke 位于 dist 后、上传前，两次尝试且无 `continue-on-error`；release CI 实跑 `smoke:packaged`（win-unpacked 实启 + 内嵌 DSH_SMOKE 断言，阻断发版） |
 | Manual / QA | `TC-INST-001`（GUI 安装走查）、`TC-INST-009`（`/S` 覆盖升级）、`TC-INST-010`（卸载）、`TC-INST-012/013` in [production-acceptance-test-cases.md](../qa/production-acceptance-test-cases.md)；每次改品牌位图后对 CI windows artifact 目检欢迎/许可/目录/完成/卸载五页——实机执行清单（artifact 下载/SHA256/逐页 checklist/zh_CN）固化在 [TC-INST-RUNBOOK.md](../qa/results/2026-08-25/installer-branding/TC-INST-RUNBOOK.md) |
 
 ## Sources

--- a/scripts/prepare-chisacode-remote.mjs
+++ b/scripts/prepare-chisacode-remote.mjs
@@ -10,6 +10,8 @@ const buildRuntime = process.argv.includes('--runtime');
 const serverExport = path.join(vendor, 'packages', 'server', 'dist', 'server', 'server', 'exports.js');
 const mobileBundle = path.join(root, 'mobile', 'web', 'chisacode', 'daemon-client.bundle.js');
 const runtimeRoot = path.join(vendor, '.tmp', 'desktop-runtime');
+const electronPackage = path.join(root, 'node_modules', 'electron', 'package.json');
+const electronRebuildCli = path.join(root, 'node_modules', '@electron', 'rebuild', 'lib', 'cli.js');
 
 function run(command, args, cwd, { shell = process.platform === 'win32' } = {}) {
   // Absolute node paths with spaces break under shell:true on Windows.
@@ -21,6 +23,62 @@ function run(command, args, cwd, { shell = process.platform === 'win32' } = {}) 
   if (result.status !== 0) {
     process.exit(result.status || 1);
   }
+}
+
+function electronExecutable() {
+  const dist = path.join(root, 'node_modules', 'electron', 'dist');
+  if (process.platform === 'win32') return path.join(dist, 'electron.exe');
+  if (process.platform === 'darwin') {
+    return path.join(dist, 'Electron.app', 'Contents', 'MacOS', 'Electron');
+  }
+  return path.join(dist, 'electron');
+}
+
+function prepareElectronSqliteRuntime() {
+  if (!fs.existsSync(electronPackage) || !fs.existsSync(electronRebuildCli)) {
+    throw new Error('[chisacode] Electron or @electron/rebuild is missing; run npm ci first');
+  }
+  const electronVersion = JSON.parse(fs.readFileSync(electronPackage, 'utf8')).version;
+  console.log(`[chisacode] rebuilding better-sqlite3 for Electron ${electronVersion}`);
+  run(
+    process.execPath,
+    [
+      electronRebuildCli,
+      '--version', electronVersion,
+      '--module-dir', runtimeRoot,
+      '--only', 'better-sqlite3',
+      '--force',
+      ...(process.platform === 'win32' ? ['--sequential'] : []),
+    ],
+    root,
+    { shell: false },
+  );
+
+  const sqlitePackage = path.join(runtimeRoot, 'node_modules', 'better-sqlite3');
+  const executable = electronExecutable();
+  if (!fs.existsSync(executable)) {
+    throw new Error(`[chisacode] Electron binary is missing at ${executable}`);
+  }
+  const probe = [
+    'const Database = require(process.argv[1]);',
+    "const db = new Database(':memory:');",
+    "db.exec('create table qa(v integer); insert into qa values (29)');",
+    "const value = db.prepare('select v from qa').get().v;",
+    'db.close();',
+    'process.stdout.write(String(value));',
+  ].join('');
+  const result = spawnSync(executable, ['-e', probe, sqlitePackage], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+    shell: false,
+    windowsHide: true,
+  });
+  if (result.status !== 0 || result.stdout.trim() !== '29') {
+    const detail = (result.stderr || result.stdout || result.error?.message || 'unknown error').trim();
+    throw new Error(`[chisacode] Electron better-sqlite3 ABI probe failed: ${detail}`);
+  }
+  console.log('[chisacode] Electron better-sqlite3 ABI probe passed');
 }
 
 function newestMtime(target) {
@@ -91,6 +149,7 @@ if (buildRuntime) {
     ['install', '--install-links', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'],
     runtimeRoot,
   );
+  prepareElectronSqliteRuntime();
 }
 
 console.log('[chisacode] ready');

--- a/src/main/chisacode-remote.test.js
+++ b/src/main/chisacode-remote.test.js
@@ -46,6 +46,11 @@ test('desktop start and packaging prepare and ship the ChisaCode runtime', () =>
   assert.match(manifest.scripts.start, /prestart-ensure/);
   assert.match(manifest.scripts.pack, /prepare-chisacode-remote\.mjs --force --runtime/);
   assert.match(prepareScript, /--install-links/);
+  assert.match(prepareScript, /@electron['"], 'rebuild'/);
+  assert.match(prepareScript, /'--only', 'better-sqlite3'/);
+  assert.doesNotMatch(prepareScript, /'--which-module', 'better-sqlite3'/);
+  assert.match(prepareScript, /ELECTRON_RUN_AS_NODE: '1'/);
+  assert.match(prepareScript, /Electron better-sqlite3 ABI probe passed/);
   const resources = manifest.build.extraResources;
   assert.ok(resources.some((entry) => (
     entry.from === 'vendor/chisacode-remote'

--- a/src/main/ci-isolation.test.js
+++ b/src/main/ci-isolation.test.js
@@ -128,6 +128,14 @@ test('release job requires a green same-SHA Desktop tests run before publishing'
   assert.ok(publishAt > gateAt, 'the CI gate must run before gh release create');
 });
 
+test('manual release candidates default to Windows-only', () => {
+  const yml = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
+  assert.match(yml, /workflow_dispatch:\r?\n\s+inputs:\r?\n\s+include_macos:/);
+  assert.match(yml, /include_macos:[\s\S]*?type: boolean[\s\S]*?default: false/);
+  const macos = yml.slice(yml.indexOf('\n  macos:'), yml.indexOf('\n  release:'));
+  assert.match(macos, /if: \$\{\{ github\.event_name == 'push' \|\| inputs\.include_macos \}\}/);
+});
+
 test('release.yml still publishes when Windows succeeds and macOS fails (documented policy)', () => {
   const yml = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release.yml'), 'utf8');
   assert.match(yml, /always\(\)/);


### PR DESCRIPTION
## Summary
- rebuild packaged better-sqlite3 specifically for Electron 43
- run an Electron ABI 148 in-memory SQLite probe before installer creation
- add a regression assertion and update the feature verification record

## Verification
- npm test: 1402 passed, 2 skipped, 0 failed
- npm run dist: passed
- packaged Electron SQLite probe: passed
- npm run smoke:packaged: passed

Web second-client and Android acceptance are excluded from the Windows 0.2.9 release scope per product-owner direction; this PR does not claim those tracks passed.